### PR TITLE
Update to aas-core-codegen 0.0.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
             "coverage>=6,<7",
             "twine",
             "aas-core-meta==2022.6.20",
-            "aas-core-codegen==0.0.13",
+            "aas-core-codegen==0.0.15",
             "hypothesis==6.46.3",
         ]
     },


### PR DESCRIPTION
We were already working locally with the main branch of
aas-core-codegen instead of the version indicated in ``setup.py``.
This patch pins the latest version so that the remote CI passes as
well.