### PR TITLE
Test for all null items in lists in JSON

### DIFF
--- a/test_data/Json/Unexpected/NullViolation/AdministrativeInformation/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/AdministrativeInformation/dataSpecifications_item.json
@@ -1,0 +1,16 @@
+{
+  "assetAdministrationShells": [
+    {
+      "administration": {
+        "dataSpecifications": [
+          null
+        ]
+      },
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/annotations_item.json
+++ b/test_data/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/annotations_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "annotations": [
+            null
+          ],
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "AnnotatedRelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/dataSpecifications_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "AnnotatedRelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/extensions_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "AnnotatedRelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/qualifiers_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "AnnotatedRelationshipElement",
+          "qualifiers": [
+            null
+          ],
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/AnnotatedRelationshipElement/supplementalSemanticIds_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "AnnotatedRelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/AssetAdministrationShell/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/AssetAdministrationShell/dataSpecifications_item.json
@@ -1,0 +1,14 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "dataSpecifications": [
+        null
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/AssetAdministrationShell/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/AssetAdministrationShell/extensions_item.json
@@ -1,0 +1,14 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        null
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/AssetAdministrationShell/submodels_item.json
+++ b/test_data/Json/Unexpected/NullViolation/AssetAdministrationShell/submodels_item.json
@@ -1,0 +1,14 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell",
+      "submodels": [
+        null
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/BasicEventElement/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/BasicEventElement/dataSpecifications_item.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "direction": "OUTPUT",
+          "modelType": "BasicEventElement",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "something_random_d041916a"
+              },
+              {
+                "type": "Referable",
+                "value": "something_random_c0f0d84b"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "OFF"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/BasicEventElement/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/BasicEventElement/extensions_item.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "OUTPUT",
+          "extensions": [
+            null
+          ],
+          "modelType": "BasicEventElement",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "something_random_d041916a"
+              },
+              {
+                "type": "Referable",
+                "value": "something_random_c0f0d84b"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "OFF"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/BasicEventElement/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/BasicEventElement/qualifiers_item.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "OUTPUT",
+          "modelType": "BasicEventElement",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "something_random_d041916a"
+              },
+              {
+                "type": "Referable",
+                "value": "something_random_c0f0d84b"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "qualifiers": [
+            null
+          ],
+          "state": "OFF"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/BasicEventElement/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/BasicEventElement/supplementalSemanticIds_item.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "OUTPUT",
+          "modelType": "BasicEventElement",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "something_random_d041916a"
+              },
+              {
+                "type": "Referable",
+                "value": "something_random_c0f0d84b"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "OFF",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Blob/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Blob/dataSpecifications_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "Blob"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Blob/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Blob/extensions_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "extensions": [
+            null
+          ],
+          "modelType": "Blob"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Blob/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Blob/qualifiers_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "modelType": "Blob",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Blob/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Blob/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "modelType": "Blob",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Capability/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Capability/dataSpecifications_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "Capability"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Capability/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Capability/extensions_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "Capability"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Capability/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Capability/qualifiers_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Capability",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Capability/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Capability/supplementalSemanticIds_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Capability",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/ConceptDescription/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/ConceptDescription/dataSpecifications_item.json
@@ -1,0 +1,11 @@
+{
+  "conceptDescriptions": [
+    {
+      "dataSpecifications": [
+        null
+      ],
+      "id": "something_random_7d1e962e",
+      "modelType": "ConceptDescription"
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/ConceptDescription/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/ConceptDescription/extensions_item.json
@@ -1,0 +1,11 @@
+{
+  "conceptDescriptions": [
+    {
+      "extensions": [
+        null
+      ],
+      "id": "something_random_7d1e962e",
+      "modelType": "ConceptDescription"
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/ConceptDescription/isCaseOf_item.json
+++ b/test_data/Json/Unexpected/NullViolation/ConceptDescription/isCaseOf_item.json
@@ -1,0 +1,11 @@
+{
+  "conceptDescriptions": [
+    {
+      "id": "something_random_7d1e962e",
+      "isCaseOf": [
+        null
+      ],
+      "modelType": "ConceptDescription"
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Entity/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Entity/dataSpecifications_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "entityType": "SelfManagedEntity",
+          "modelType": "Entity"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Entity/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Entity/extensions_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "SelfManagedEntity",
+          "extensions": [
+            null
+          ],
+          "modelType": "Entity"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Entity/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Entity/qualifiers_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "SelfManagedEntity",
+          "modelType": "Entity",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Entity/statements_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Entity/statements_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "SelfManagedEntity",
+          "modelType": "Entity",
+          "statements": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Entity/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Entity/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "SelfManagedEntity",
+          "modelType": "Entity",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Environment/assetAdministrationShells_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Environment/assetAdministrationShells_item.json
@@ -1,0 +1,5 @@
+{
+  "assetAdministrationShells": [
+    null
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Environment/conceptDescriptions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Environment/conceptDescriptions_item.json
@@ -1,0 +1,5 @@
+{
+  "conceptDescriptions": [
+    null
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Environment/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Environment/dataSpecifications_item.json
@@ -1,0 +1,5 @@
+{
+  "dataSpecifications": [
+    null
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Environment/submodels_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Environment/submodels_item.json
@@ -1,0 +1,5 @@
+{
+  "submodels": [
+    null
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Extension/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Extension/supplementalSemanticIds_item.json
@@ -1,0 +1,20 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "supplementalSemanticIds": [
+            null
+          ],
+          "valueType": "xs:boolean"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/File/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/File/dataSpecifications_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "File"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/File/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/File/extensions_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "extensions": [
+            null
+          ],
+          "modelType": "File"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/File/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/File/qualifiers_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "modelType": "File",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/File/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/File/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "application/something-random",
+          "modelType": "File",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/MultiLanguageProperty/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/MultiLanguageProperty/dataSpecifications_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "MultiLanguageProperty"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/MultiLanguageProperty/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/MultiLanguageProperty/extensions_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "MultiLanguageProperty"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/MultiLanguageProperty/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/MultiLanguageProperty/qualifiers_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "MultiLanguageProperty",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/MultiLanguageProperty/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/MultiLanguageProperty/supplementalSemanticIds_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "MultiLanguageProperty",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Operation/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Operation/dataSpecifications_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "Operation"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Operation/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Operation/extensions_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "Operation"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Operation/inoutputVariables_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Operation/inoutputVariables_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "inoutputVariables": [
+            null
+          ],
+          "modelType": "Operation"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Operation/inputVariables_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Operation/inputVariables_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "inputVariables": [
+            null
+          ],
+          "modelType": "Operation"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Operation/outputVariables_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Operation/outputVariables_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Operation",
+          "outputVariables": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Operation/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Operation/qualifiers_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Operation",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Operation/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Operation/supplementalSemanticIds_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Operation",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Property/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Property/dataSpecifications_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "Property",
+          "valueType": "xs:boolean"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Property/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Property/extensions_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "Property",
+          "valueType": "xs:boolean"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Property/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Property/qualifiers_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Property",
+          "qualifiers": [
+            null
+          ],
+          "valueType": "xs:boolean"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Property/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Property/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Property",
+          "supplementalSemanticIds": [
+            null
+          ],
+          "valueType": "xs:boolean"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Qualifier/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Qualifier/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "supplementalSemanticIds": [
+            null
+          ],
+          "type": "something_random_cfd39ba4",
+          "valueType": "xs:boolean"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Range/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Range/dataSpecifications_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "Range",
+          "valueType": "xs:int"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Range/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Range/extensions_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "Range",
+          "valueType": "xs:int"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Range/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Range/qualifiers_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Range",
+          "qualifiers": [
+            null
+          ],
+          "valueType": "xs:int"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Range/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Range/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "Range",
+          "supplementalSemanticIds": [
+            null
+          ],
+          "valueType": "xs:int"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/ReferenceElement/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/ReferenceElement/dataSpecifications_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "ReferenceElement"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/ReferenceElement/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/ReferenceElement/extensions_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "ReferenceElement"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/ReferenceElement/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/ReferenceElement/qualifiers_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "ReferenceElement",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/ReferenceElement/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/ReferenceElement/supplementalSemanticIds_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "ReferenceElement",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/RelationshipElement/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/RelationshipElement/dataSpecifications_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "RelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/RelationshipElement/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/RelationshipElement/extensions_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "RelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/RelationshipElement/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/RelationshipElement/qualifiers_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "RelationshipElement",
+          "qualifiers": [
+            null
+          ],
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/RelationshipElement/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/RelationshipElement/supplementalSemanticIds_item.json
@@ -1,0 +1,34 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_40549f9f"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "modelType": "RelationshipElement",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_3945ca3e"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/SpecificAssetId/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/SpecificAssetId/supplementalSemanticIds_item.json
@@ -1,0 +1,27 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance",
+        "specificAssetId": {
+          "externalSubjectId": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "something_random_ecd20100"
+              }
+            ],
+            "type": "GlobalReference"
+          },
+          "name": "something_random_73ff3355",
+          "supplementalSemanticIds": [
+            null
+          ],
+          "value": "something_random_d43e0a3b"
+        }
+      },
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Submodel/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Submodel/dataSpecifications_item.json
@@ -1,0 +1,11 @@
+{
+  "submodels": [
+    {
+      "dataSpecifications": [
+        null
+      ],
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel"
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Submodel/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Submodel/extensions_item.json
@@ -1,0 +1,11 @@
+{
+  "submodels": [
+    {
+      "extensions": [
+        null
+      ],
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel"
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Submodel/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Submodel/qualifiers_item.json
@@ -1,0 +1,11 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        null
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Submodel/submodelElements_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Submodel/submodelElements_item.json
@@ -1,0 +1,11 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        null
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/Submodel/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/Submodel/supplementalSemanticIds_item.json
@@ -1,0 +1,11 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "supplementalSemanticIds": [
+        null
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/SubmodelElementCollection/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/SubmodelElementCollection/dataSpecifications_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "SubmodelElementCollection"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/SubmodelElementCollection/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/SubmodelElementCollection/extensions_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "SubmodelElementCollection"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/SubmodelElementCollection/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/SubmodelElementCollection/qualifiers_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "SubmodelElementCollection",
+          "qualifiers": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/SubmodelElementCollection/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/SubmodelElementCollection/supplementalSemanticIds_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "SubmodelElementCollection",
+          "supplementalSemanticIds": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/SubmodelElementCollection/value_item.json
+++ b/test_data/Json/Unexpected/NullViolation/SubmodelElementCollection/value_item.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "SubmodelElementCollection",
+          "value": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/SubmodelElementList/dataSpecifications_item.json
+++ b/test_data/Json/Unexpected/NullViolation/SubmodelElementList/dataSpecifications_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "dataSpecifications": [
+            null
+          ],
+          "modelType": "SubmodelElementList",
+          "typeValueListElement": "SubmodelElementCollection"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/SubmodelElementList/extensions_item.json
+++ b/test_data/Json/Unexpected/NullViolation/SubmodelElementList/extensions_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "extensions": [
+            null
+          ],
+          "modelType": "SubmodelElementList",
+          "typeValueListElement": "SubmodelElementCollection"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/SubmodelElementList/qualifiers_item.json
+++ b/test_data/Json/Unexpected/NullViolation/SubmodelElementList/qualifiers_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "SubmodelElementList",
+          "qualifiers": [
+            null
+          ],
+          "typeValueListElement": "SubmodelElementCollection"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/SubmodelElementList/supplementalSemanticIds_item.json
+++ b/test_data/Json/Unexpected/NullViolation/SubmodelElementList/supplementalSemanticIds_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "SubmodelElementList",
+          "supplementalSemanticIds": [
+            null
+          ],
+          "typeValueListElement": "SubmodelElementCollection"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/Unexpected/NullViolation/SubmodelElementList/value_item.json
+++ b/test_data/Json/Unexpected/NullViolation/SubmodelElementList/value_item.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "modelType": "SubmodelElementList",
+          "typeValueListElement": "SubmodelElementCollection",
+          "value": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
We tested only for mandatory properties (lists and non-lists alike). In
this patch, we also test for optional list properties containing
``null`` as item.