### PR TITLE
Update to aas-core-codegen 9a0b74b

### DIFF
--- a/aas_core3_0_rc02_testgen/generate_xml.py
+++ b/aas_core3_0_rc02_testgen/generate_xml.py
@@ -214,8 +214,7 @@ class _Serializer:
         # We need to re-order the sequence so that it strictly follows the order of the
         # properties in the meta-model. Otherwise, the XML schema will complain.
 
-        cls = self.symbol_table.must_find(instance.model_type)
-        assert isinstance(cls, intermediate.ConcreteClass)
+        cls = self.symbol_table.must_find_concrete_class(instance.model_type)
 
         order_map = {prop.name: i for i, prop in enumerate(cls.properties)}
 
@@ -244,10 +243,7 @@ class _Serializer:
             elif isinstance(prop_value, generation.Instance):
                 subsequence = self._serialize_instance(prop_value, doc)
 
-                a_cls = self.symbol_table.must_find(prop_value.model_type)
-                assert isinstance(
-                    a_cls, (intermediate.AbstractClass, intermediate.ConcreteClass)
-                )
+                a_cls = self.symbol_table.must_find_class(prop_value.model_type)
 
                 if (
                     a_cls.serialization is not None
@@ -337,8 +333,7 @@ def generate(test_data_dir: pathlib.Path) -> None:
 
     serializer = _Serializer(symbol_table=symbol_table)
 
-    environment_cls = symbol_table.must_find(Identifier("Environment"))
-    assert isinstance(environment_cls, intermediate.ConcreteClass)
+    environment_cls = symbol_table.must_find_concrete_class(Identifier("Environment"))
 
     for test_case in generation.generate(
         symbol_table=symbol_table,

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
             "coverage>=6,<7",
             "twine",
             "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@5f563af#egg=aas-core-meta",
-            "aas-core-codegen==0.0.15",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@9a0b74b#egg=aas-core-meta",
             "hypothesis==6.46.3",
             "xmlschema==1.10.0",
         ]


### PR DESCRIPTION
We update the code to use [aas-core-codegen 9a0b74b]. Notably, we
propagate the renaming "symbol" to "our type", and use the novel
``must_find_*`` methods to simplify the code.

[aas-core-codegen 9a0b74b]: https://github.com/aas-core-works/aas-core-codegen/commit/9a0b74b