### PR TITLE
Fix aas-core-codegen link in ``setup.py``

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
             "coverage>=6,<7",
             "twine",
             "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@5f563af#egg=aas-core-meta",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@9a0b74b#egg=aas-core-meta",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@9a0b74b#egg=aas-core-codegen",
             "hypothesis==6.46.3",
             "xmlschema==1.10.0",
         ]


### PR DESCRIPTION
We fix the egg identifier in the development dependencies.