### PR TITLE
Generate test cases with constant sets

### DIFF
--- a/aas_core3_0_rc02_testgen/generate_json.py
+++ b/aas_core3_0_rc02_testgen/generate_json.py
@@ -137,6 +137,11 @@ def _relative_path(
     elif isinstance(test_case, generation.CasePositiveManual):
         return base_pth / f"{test_case.name}.json"
 
+    elif isinstance(test_case, generation.CaseSetViolation):
+        prop_name = aas_core_codegen.naming.json_property(test_case.property_name)
+
+        return base_pth / f"{prop_name}.json"
+
     elif isinstance(test_case, generation.CaseConstraintViolation):
         return base_pth / f"{test_case.name}.json"
 

--- a/aas_core3_0_rc02_testgen/generate_xml.py
+++ b/aas_core3_0_rc02_testgen/generate_xml.py
@@ -133,6 +133,11 @@ def _relative_path(
     elif isinstance(test_case, generation.CasePositiveManual):
         return base_pth / f"{test_case.name}.xml"
 
+    elif isinstance(test_case, generation.CaseSetViolation):
+        prop_name = aas_core_codegen.naming.xml_property(test_case.property_name)
+
+        return base_pth / f"{prop_name}.xml"
+
     elif isinstance(test_case, generation.CaseConstraintViolation):
         return base_pth / f"{test_case.name}.xml"
 

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(
             "pydocstyle>=2.1.1<3",
             "coverage>=6,<7",
             "twine",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@93f0af2#egg=aas-core-meta",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@9a0b74b#egg=aas-core-codegen",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@5c6ac67#egg=aas-core-meta",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@6b55dbc#egg=aas-core-codegen",
             "hypothesis==6.46.3",
             "xmlschema==1.10.0",
         ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Blob/complete.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Blob/complete.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Expected/ConceptDescription/complete.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/ConceptDescription/complete.json
@@ -2,7 +2,7 @@
   "conceptDescriptions": [
     {
       "administration": {},
-      "category": "VALUE",
+      "category": "DOCUMENT",
       "checksum": "something_random_3362add6",
       "dataSpecifications": [
         {

--- a/test_data/Json/ContainedInEnvironment/Expected/File/complete.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/File/complete.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Expected/MultiLanguageProperty/complete.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/MultiLanguageProperty/complete.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/complete.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/complete.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/complete.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/complete.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Expected/ReferenceElement/complete.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/ReferenceElement/complete.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/Blob/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/Blob/category.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "category": "unexpected value",
+          "contentType": "application/something-random",
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Blob"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/ConceptDescription/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/ConceptDescription/category.json
@@ -1,0 +1,9 @@
+{
+  "conceptDescriptions": [
+    {
+      "category": "unexpected value",
+      "id": "something_random_7d1e962e",
+      "modelType": "ConceptDescription"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/File/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/File/category.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "category": "unexpected value",
+          "contentType": "application/something-random",
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "File"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/MultiLanguageProperty/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/MultiLanguageProperty/category.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "category": "unexpected value",
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "MultiLanguageProperty"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/Property/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/Property/category.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "category": "unexpected value",
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "valueType": "xs:boolean"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/Range/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/Range/category.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "category": "unexpected value",
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Range",
+          "valueType": "xs:int"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/ReferenceElement/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/SetViolation/ReferenceElement/category.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "category": "unexpected value",
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "ReferenceElement"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/checksum.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/checksum.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/contentType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/contentType.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": {
             "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/dataSpecifications.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/dataSpecifications.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": "Unexpected string value",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/description.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/description.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/displayName.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/displayName.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/extensions.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/extensions.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/idShort.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/kind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/kind.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/qualifiers.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/qualifiers.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/supplementalSemanticIds.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/supplementalSemanticIds.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/value.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json
@@ -2,7 +2,7 @@
   "conceptDescriptions": [
     {
       "administration": "Unexpected string value",
-      "category": "VALUE",
+      "category": "DOCUMENT",
       "checksum": "something_random_3362add6",
       "dataSpecifications": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/checksum.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/checksum.json
@@ -2,7 +2,7 @@
   "conceptDescriptions": [
     {
       "administration": {},
-      "category": "VALUE",
+      "category": "DOCUMENT",
       "checksum": {
         "keys": [
           {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/dataSpecifications.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/dataSpecifications.json
@@ -2,7 +2,7 @@
   "conceptDescriptions": [
     {
       "administration": {},
-      "category": "VALUE",
+      "category": "DOCUMENT",
       "checksum": "something_random_3362add6",
       "dataSpecifications": "Unexpected string value",
       "description": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/description.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/description.json
@@ -2,7 +2,7 @@
   "conceptDescriptions": [
     {
       "administration": {},
-      "category": "VALUE",
+      "category": "DOCUMENT",
       "checksum": "something_random_3362add6",
       "dataSpecifications": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/displayName.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/displayName.json
@@ -2,7 +2,7 @@
   "conceptDescriptions": [
     {
       "administration": {},
-      "category": "VALUE",
+      "category": "DOCUMENT",
       "checksum": "something_random_3362add6",
       "dataSpecifications": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/extensions.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/extensions.json
@@ -2,7 +2,7 @@
   "conceptDescriptions": [
     {
       "administration": {},
-      "category": "VALUE",
+      "category": "DOCUMENT",
       "checksum": "something_random_3362add6",
       "dataSpecifications": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/id.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/id.json
@@ -2,7 +2,7 @@
   "conceptDescriptions": [
     {
       "administration": {},
-      "category": "VALUE",
+      "category": "DOCUMENT",
       "checksum": "something_random_3362add6",
       "dataSpecifications": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/idShort.json
@@ -2,7 +2,7 @@
   "conceptDescriptions": [
     {
       "administration": {},
-      "category": "VALUE",
+      "category": "DOCUMENT",
       "checksum": "something_random_3362add6",
       "dataSpecifications": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/isCaseOf.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/isCaseOf.json
@@ -2,7 +2,7 @@
   "conceptDescriptions": [
     {
       "administration": {},
-      "category": "VALUE",
+      "category": "DOCUMENT",
       "checksum": "something_random_3362add6",
       "dataSpecifications": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/checksum.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/checksum.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/contentType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/contentType.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": {
             "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/dataSpecifications.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/dataSpecifications.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": "Unexpected string value",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/description.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/description.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/displayName.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/displayName.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/extensions.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/extensions.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/idShort.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/kind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/kind.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/qualifiers.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/qualifiers.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/supplementalSemanticIds.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/supplementalSemanticIds.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/value.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "contentType": "application/something-random",
           "dataSpecifications": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/checksum.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/checksum.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/dataSpecifications.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/dataSpecifications.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": "Unexpected string value",
           "description": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/description.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/description.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/displayName.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/displayName.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/extensions.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/extensions.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/idShort.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/kind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/kind.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/qualifiers.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/qualifiers.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/supplementalSemanticIds.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/supplementalSemanticIds.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/value.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/checksum.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/checksum.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/dataSpecifications.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/dataSpecifications.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": "Unexpected string value",
           "description": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/description.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/description.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/displayName.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/displayName.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/extensions.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/extensions.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/idShort.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/kind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/kind.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/qualifiers.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/qualifiers.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/supplementalSemanticIds.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/supplementalSemanticIds.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/value.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueType.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/checksum.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/checksum.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/dataSpecifications.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/dataSpecifications.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": "Unexpected string value",
           "description": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/description.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/description.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/displayName.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/displayName.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/extensions.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/extensions.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/idShort.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/kind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/kind.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/max.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/max.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/min.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/min.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/qualifiers.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/qualifiers.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/supplementalSemanticIds.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/supplementalSemanticIds.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/valueType.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/checksum.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/checksum.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/dataSpecifications.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/dataSpecifications.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": "Unexpected string value",
           "description": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/description.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/description.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/displayName.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/displayName.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/extensions.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/extensions.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/idShort.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/kind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/kind.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/qualifiers.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/qualifiers.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/supplementalSemanticIds.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/supplementalSemanticIds.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json
@@ -5,7 +5,7 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": "CONSTANT",
+          "category": "PARAMETER",
           "checksum": "something_random_9711a3c9",
           "dataSpecifications": [
             {

--- a/test_data/Xml/ContainedInEnvironment/Expected/blob/complete.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/blob/complete.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Expected/conceptDescription/complete.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/conceptDescription/complete.xml
@@ -7,7 +7,7 @@
 					<valueType>xs:boolean</valueType>
 				</extension>
 			</extensions>
-			<category>VALUE</category>
+			<category>DOCUMENT</category>
 			<idShort>Z0</idShort>
 			<displayName>
 				<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Expected/file/complete.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/file/complete.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Expected/multiLanguageProperty/complete.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/multiLanguageProperty/complete.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/complete.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/complete.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/complete.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/complete.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Expected/referenceElement/complete.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/referenceElement/complete.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/blob/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/blob/category.xml
@@ -1,0 +1,14 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<blob>
+					<category>unexpected value</category>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<contentType>application/something-random</contentType>
+				</blob>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/conceptDescription/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/conceptDescription/category.xml
@@ -1,0 +1,8 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<conceptDescriptions>
+		<conceptDescription>
+			<category>unexpected value</category>
+			<id>something_random_7d1e962e</id>
+		</conceptDescription>
+	</conceptDescriptions>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/file/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/file/category.xml
@@ -1,0 +1,14 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<file>
+					<category>unexpected value</category>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<contentType>application/something-random</contentType>
+				</file>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/multiLanguageProperty/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/multiLanguageProperty/category.xml
@@ -1,0 +1,13 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<multiLanguageProperty>
+					<category>unexpected value</category>
+					<idShort>some_id_short_10b21b1b</idShort>
+				</multiLanguageProperty>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/property/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/property/category.xml
@@ -1,0 +1,14 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<category>unexpected value</category>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:boolean</valueType>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/range/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/range/category.xml
@@ -1,0 +1,14 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<category>unexpected value</category>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:int</valueType>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/referenceElement/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/SetViolation/referenceElement/category.xml
@@ -1,0 +1,13 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<referenceElement>
+					<category>unexpected value</category>
+					<idShort>some_id_short_10b21b1b</idShort>
+				</referenceElement>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/checksum.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/checksum.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/contentType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/contentType.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/dataSpecifications.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/dataSpecifications.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/description.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/description.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/displayName.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/displayName.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>Unexpected string value</displayName>
 					<description>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/extensions.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/extensions.xml
@@ -5,7 +5,7 @@
 			<submodelElements>
 				<blob>
 					<extensions>Unexpected string value</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/idShort.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>
 						<type>GlobalReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/kind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/kind.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/qualifiers.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/qualifiers.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/semanticId.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/supplementalSemanticIds.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/supplementalSemanticIds.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/value.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/administration.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/administration.xml
@@ -7,7 +7,7 @@
 					<valueType>xs:boolean</valueType>
 				</extension>
 			</extensions>
-			<category>VALUE</category>
+			<category>DOCUMENT</category>
 			<idShort>Z0</idShort>
 			<displayName>
 				<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/checksum.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/checksum.xml
@@ -7,7 +7,7 @@
 					<valueType>xs:boolean</valueType>
 				</extension>
 			</extensions>
-			<category>VALUE</category>
+			<category>DOCUMENT</category>
 			<idShort>Z0</idShort>
 			<displayName>
 				<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/dataSpecifications.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/dataSpecifications.xml
@@ -7,7 +7,7 @@
 					<valueType>xs:boolean</valueType>
 				</extension>
 			</extensions>
-			<category>VALUE</category>
+			<category>DOCUMENT</category>
 			<idShort>Z0</idShort>
 			<displayName>
 				<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/description.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/description.xml
@@ -7,7 +7,7 @@
 					<valueType>xs:boolean</valueType>
 				</extension>
 			</extensions>
-			<category>VALUE</category>
+			<category>DOCUMENT</category>
 			<idShort>Z0</idShort>
 			<displayName>
 				<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/displayName.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/displayName.xml
@@ -7,7 +7,7 @@
 					<valueType>xs:boolean</valueType>
 				</extension>
 			</extensions>
-			<category>VALUE</category>
+			<category>DOCUMENT</category>
 			<idShort>Z0</idShort>
 			<displayName>Unexpected string value</displayName>
 			<description>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/extensions.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/extensions.xml
@@ -2,7 +2,7 @@
 	<conceptDescriptions>
 		<conceptDescription>
 			<extensions>Unexpected string value</extensions>
-			<category>VALUE</category>
+			<category>DOCUMENT</category>
 			<idShort>Z0</idShort>
 			<displayName>
 				<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/id.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/id.xml
@@ -7,7 +7,7 @@
 					<valueType>xs:boolean</valueType>
 				</extension>
 			</extensions>
-			<category>VALUE</category>
+			<category>DOCUMENT</category>
 			<idShort>Z0</idShort>
 			<displayName>
 				<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/idShort.xml
@@ -7,7 +7,7 @@
 					<valueType>xs:boolean</valueType>
 				</extension>
 			</extensions>
-			<category>VALUE</category>
+			<category>DOCUMENT</category>
 			<idShort>
 				<type>GlobalReference</type>
 				<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/isCaseOf.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/isCaseOf.xml
@@ -7,7 +7,7 @@
 					<valueType>xs:boolean</valueType>
 				</extension>
 			</extensions>
-			<category>VALUE</category>
+			<category>DOCUMENT</category>
 			<idShort>Z0</idShort>
 			<displayName>
 				<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/checksum.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/checksum.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/contentType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/contentType.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/dataSpecifications.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/dataSpecifications.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/description.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/description.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/displayName.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/displayName.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>Unexpected string value</displayName>
 					<description>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/extensions.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/extensions.xml
@@ -5,7 +5,7 @@
 			<submodelElements>
 				<file>
 					<extensions>Unexpected string value</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/idShort.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>
 						<type>GlobalReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/kind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/kind.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/qualifiers.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/qualifiers.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/semanticId.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/supplementalSemanticIds.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/supplementalSemanticIds.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/value.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/checksum.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/checksum.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/dataSpecifications.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/dataSpecifications.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/description.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/description.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/displayName.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/displayName.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>Unexpected string value</displayName>
 					<description>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/extensions.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/extensions.xml
@@ -5,7 +5,7 @@
 			<submodelElements>
 				<multiLanguageProperty>
 					<extensions>Unexpected string value</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/idShort.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>
 						<type>GlobalReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/kind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/kind.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/qualifiers.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/qualifiers.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/semanticId.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/supplementalSemanticIds.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/supplementalSemanticIds.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/value.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/valueId.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/checksum.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/checksum.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/dataSpecifications.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/dataSpecifications.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/description.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/description.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/displayName.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/displayName.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>Unexpected string value</displayName>
 					<description>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/extensions.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/extensions.xml
@@ -5,7 +5,7 @@
 			<submodelElements>
 				<property>
 					<extensions>Unexpected string value</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/idShort.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>
 						<type>GlobalReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/kind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/kind.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/qualifiers.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/qualifiers.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/semanticId.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/supplementalSemanticIds.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/supplementalSemanticIds.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/value.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueId.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueType.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/checksum.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/checksum.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/dataSpecifications.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/dataSpecifications.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/description.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/description.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/displayName.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/displayName.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>Unexpected string value</displayName>
 					<description>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/extensions.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/extensions.xml
@@ -5,7 +5,7 @@
 			<submodelElements>
 				<range>
 					<extensions>Unexpected string value</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/idShort.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>
 						<type>GlobalReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/kind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/kind.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/max.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/max.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/min.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/min.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/qualifiers.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/qualifiers.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/semanticId.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/supplementalSemanticIds.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/supplementalSemanticIds.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/valueType.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/checksum.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/checksum.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/dataSpecifications.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/dataSpecifications.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/description.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/description.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/displayName.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/displayName.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>Unexpected string value</displayName>
 					<description>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/extensions.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/extensions.xml
@@ -5,7 +5,7 @@
 			<submodelElements>
 				<referenceElement>
 					<extensions>Unexpected string value</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/idShort.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>
 						<type>GlobalReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/kind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/kind.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/qualifiers.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/qualifiers.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/semanticId.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/supplementalSemanticIds.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/supplementalSemanticIds.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/value.xml
@@ -10,7 +10,7 @@
 							<valueType>xs:boolean</valueType>
 						</extension>
 					</extensions>
-					<category>CONSTANT</category>
+					<category>PARAMETER</category>
 					<idShort>some_id_short_10b21b1b</idShort>
 					<displayName>
 						<langStrings>


### PR DESCRIPTION
This patch relies on major changes in [aas-core-meta 5c6ac67] and
[aas-core-codegen 6b55dbc], where we introduced constants such as
constant sets of primitives and enumeration literals.

In this patch, we generate the positive examples based on these
constraints related to constant sets as well as generate negative
examples using out-of-set generation of property values.

[aas-core-meta 5c6ac67]: https://github.com/aas-core-works/aas-core-meta/commit/5c6ac67
[aas-core-codegen 6b55dbc]: https://github.com/aas-core-works/aas-core-codegen/commit/6b55dbc