### PR TITLE
Add manual cases for ``Reference``

### DIFF
--- a/.idea/csv-plugin.xml
+++ b/.idea/csv-plugin.xml
@@ -31,6 +31,13 @@
             </Attribute>
           </value>
         </entry>
+        <entry key="\setup.py">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
         <entry key="\test_data\Json\Expected\AnnotatedRelationshipElement\complete.json">
           <value>
             <Attribute>

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(
             "pydocstyle>=2.1.1<3",
             "coverage>=6,<7",
             "twine",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@5c6ac67#egg=aas-core-meta",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@6b55dbc#egg=aas-core-codegen",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@ed81978#egg=aas-core-meta",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@b944996#egg=aas-core-codegen",
             "hypothesis==6.46.3",
             "xmlschema==1.10.0",
         ]

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/complete.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/complete.json
@@ -52,7 +52,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -68,7 +68,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_01.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_02.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_02.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_03.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_03.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_04.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_04.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_05.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_05.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_06.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_07.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_07.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_08.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_08.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_09.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_10.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/idShortOverPatternExamples/fuzzed_10.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_01.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_02.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_02.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_03.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_03.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/midnight_with_24_hours.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/midnight_with_24_hours.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/midnight_with_zeros.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/midnight_with_zeros.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/random_positive.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/random_positive.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/very_large_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/very_large_year.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/very_long_fractional_second.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/lastUpdateOverPatternExamples/very_long_fractional_second.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_01.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_02.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_02.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_03.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_03.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/midnight_with_24_hours.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/midnight_with_24_hours.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/midnight_with_zeros.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/midnight_with_zeros.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/random_positive.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/random_positive.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/very_large_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/very_large_year.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/very_long_fractional_second.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/maxIntervalOverPatternExamples/very_long_fractional_second.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/fuzzed_01.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/fuzzed_02.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/fuzzed_02.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/fuzzed_03.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/fuzzed_03.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/midnight_with_24_hours.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/midnight_with_24_hours.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/midnight_with_zeros.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/midnight_with_zeros.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/random_positive.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/random_positive.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/very_large_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/very_large_year.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/very_long_fractional_second.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minIntervalOverPatternExamples/very_long_fractional_second.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minimal.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/BasicEventElement/minimal.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Expected/Reference/complete.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Reference/complete.json
@@ -1,20 +1,26 @@
 {
-  "assetAdministrationShells": [
+  "submodels": [
     {
-      "assetInformation": {
-        "assetKind": "Instance"
-      },
-      "derivedFrom": {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
         "keys": [
           {
-            "type": "AssetAdministrationShell",
-            "value": "44e7dc4a"
+            "type": "GlobalReference",
+            "value": "something_random_920ea681"
           }
         ],
-        "type": "ModelReference"
-      },
-      "id": "something_random_428f0205",
-      "modelType": "AssetAdministrationShell"
+        "referredSemanticId": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "something_random_01ef5a5b"
+            }
+          ],
+          "type": "GlobalReference"
+        },
+        "type": "GlobalReference"
+      }
     }
   ]
 }

--- a/test_data/Json/ContainedInEnvironment/Expected/Reference/for_a_global_reference_first_key_in_generic_globally_identifiables.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Reference/for_a_global_reference_first_key_in_generic_globally_identifiables.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "value": "something"
+          }
+        ],
+        "type": "GlobalReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Reference/for_a_global_reference_last_key_in_generic_fragment_keys.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Reference/for_a_global_reference_last_key_in_generic_fragment_keys.json
@@ -1,0 +1,21 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "value": "something"
+          },
+          {
+            "type": "FragmentReference",
+            "value": "something_more"
+          }
+        ],
+        "type": "GlobalReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Reference/for_a_global_reference_last_key_in_generic_globally_identifiable.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Reference/for_a_global_reference_last_key_in_generic_globally_identifiable.json
@@ -1,0 +1,21 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "value": "something"
+          },
+          {
+            "type": "GlobalReference",
+            "value": "something_more"
+          }
+        ],
+        "type": "GlobalReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Reference/for_a_model_reference_first_key_in_globally_and_aas_identifiables.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Reference/for_a_model_reference_first_key_in_globally_and_aas_identifiables.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "Submodel",
+            "value": "something"
+          }
+        ],
+        "type": "ModelReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Reference/for_a_model_reference_fragment_after_blob.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Reference/for_a_model_reference_fragment_after_blob.json
@@ -1,0 +1,25 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "Submodel",
+            "value": "something"
+          },
+          {
+            "type": "Blob",
+            "value": "something_more"
+          },
+          {
+            "type": "FragmentReference",
+            "value": "yet_something_more"
+          }
+        ],
+        "type": "ModelReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Reference/for_a_model_reference_valid_key_value_after_submodel_element_list.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Reference/for_a_model_reference_valid_key_value_after_submodel_element_list.json
@@ -1,0 +1,25 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "Submodel",
+            "value": "something"
+          },
+          {
+            "type": "SubmodelElementList",
+            "value": "something_more"
+          },
+          {
+            "type": "Property",
+            "value": "123"
+          }
+        ],
+        "type": "ModelReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Reference/minimal.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Reference/minimal.json
@@ -1,20 +1,17 @@
 {
-  "assetAdministrationShells": [
+  "submodels": [
     {
-      "assetInformation": {
-        "assetKind": "Instance"
-      },
-      "derivedFrom": {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
         "keys": [
           {
-            "type": "AssetAdministrationShell",
-            "value": "44e7dc4a"
+            "type": "GlobalReference",
+            "value": "something_random_920ea681"
           }
         ],
-        "type": "ModelReference"
-      },
-      "id": "something_random_428f0205",
-      "modelType": "AssetAdministrationShell"
+        "type": "GlobalReference"
+      }
     }
   ]
 }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/first_key_not_in_globally_identifiables.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/first_key_not_in_globally_identifiables.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "Blob",
+            "value": "something"
+          }
+        ],
+        "type": "ModelReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_global_reference_first_key_not_in_generic_globally_identifiables.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_global_reference_first_key_not_in_generic_globally_identifiables.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "Blob",
+            "value": "something"
+          }
+        ],
+        "type": "GlobalReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_global_reference_invalid_last_key.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_global_reference_invalid_last_key.json
@@ -1,0 +1,21 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "value": "something"
+          },
+          {
+            "type": "Blob",
+            "value": "something_more"
+          }
+        ],
+        "type": "GlobalReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_model_reference_first_key_not_in_AAS_identifiables.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_model_reference_first_key_not_in_AAS_identifiables.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "GlobalReference",
+            "value": "something"
+          }
+        ],
+        "type": "ModelReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_model_reference_fragment_reference_in_the_middle.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_model_reference_fragment_reference_in_the_middle.json
@@ -1,0 +1,25 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "Submodel",
+            "value": "something"
+          },
+          {
+            "type": "FragmentReference",
+            "value": "something_more"
+          },
+          {
+            "type": "Property",
+            "value": "yet_something_more"
+          }
+        ],
+        "type": "ModelReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_model_reference_fragment_reference_not_after_file_or_blob.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_model_reference_fragment_reference_not_after_file_or_blob.json
@@ -1,0 +1,25 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "Submodel",
+            "value": "something"
+          },
+          {
+            "type": "Property",
+            "value": "something_more"
+          },
+          {
+            "type": "FragmentReference",
+            "value": "yet_something_more"
+          }
+        ],
+        "type": "ModelReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_model_reference_invalid_key_value_after_submodel_element_list.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_model_reference_invalid_key_value_after_submodel_element_list.json
@@ -1,0 +1,25 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "Submodel",
+            "value": "something"
+          },
+          {
+            "type": "SubmodelElementList",
+            "value": "something_more"
+          },
+          {
+            "type": "Property",
+            "value": "-1"
+          }
+        ],
+        "type": "ModelReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_model_reference_second_key_not_in_fragment_keys.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/ConstraintViolation/Reference/for_a_model_reference_second_key_not_in_fragment_keys.json
@@ -1,0 +1,21 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "Submodel",
+            "value": "something"
+          },
+          {
+            "type": "GlobalReference",
+            "value": "something_more"
+          }
+        ],
+        "type": "ModelReference"
+      }
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/DateTimeStampUtcViolationOnFebruary29th/BasicEventElement/lastUpdate.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/DateTimeStampUtcViolationOnFebruary29th/BasicEventElement/lastUpdate.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/DateTimeStampUtcViolationOnFebruary29th/BasicEventElement/maxInterval.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/DateTimeStampUtcViolationOnFebruary29th/BasicEventElement/maxInterval.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/DateTimeStampUtcViolationOnFebruary29th/BasicEventElement/minInterval.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/DateTimeStampUtcViolationOnFebruary29th/BasicEventElement/minInterval.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/BasicEventElement/direction_as_Direction.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/BasicEventElement/direction_as_Direction.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/BasicEventElement/kind_as_ModelingKind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/BasicEventElement/kind_as_ModelingKind.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/BasicEventElement/state_as_StateOfEvent.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/BasicEventElement/state_as_StateOfEvent.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/Reference/type_as_ReferenceTypes.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/Reference/type_as_ReferenceTypes.json
@@ -1,20 +1,17 @@
 {
-  "assetAdministrationShells": [
+  "submodels": [
     {
-      "assetInformation": {
-        "assetKind": "Instance"
-      },
-      "derivedFrom": {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
         "keys": [
           {
-            "type": "AssetAdministrationShell",
-            "value": "44e7dc4a"
+            "type": "GlobalReference",
+            "value": "something_random_920ea681"
           }
         ],
         "type": "invalid-literal"
-      },
-      "id": "something_random_428f0205",
-      "modelType": "AssetAdministrationShell"
+      }
     }
   ]
 }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/MaxLengthViolation/BasicEventElement/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/MaxLengthViolation/BasicEventElement/idShort.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/BasicEventElement/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/BasicEventElement/category.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/BasicEventElement/checksum.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/BasicEventElement/checksum.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/BasicEventElement/messageTopic.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/BasicEventElement/messageTopic.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/Reference/keys.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/Reference/keys.json
@@ -1,15 +1,12 @@
 {
-  "assetAdministrationShells": [
+  "submodels": [
     {
-      "assetInformation": {
-        "assetKind": "Instance"
-      },
-      "derivedFrom": {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
         "keys": [],
-        "type": "ModelReference"
-      },
-      "id": "something_random_428f0205",
-      "modelType": "AssetAdministrationShell"
+        "type": "GlobalReference"
+      }
     }
   ]
 }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/BasicEventElement/dataSpecifications_item.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/BasicEventElement/dataSpecifications_item.json
@@ -18,7 +18,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/BasicEventElement/direction_value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/BasicEventElement/direction_value.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/BasicEventElement/extensions_item.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/BasicEventElement/extensions_item.json
@@ -18,7 +18,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/BasicEventElement/qualifiers_item.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/BasicEventElement/qualifiers_item.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/BasicEventElement/state_value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/BasicEventElement/state_value.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/BasicEventElement/supplementalSemanticIds_item.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/BasicEventElement/supplementalSemanticIds_item.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/Reference/keys_item.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/Reference/keys_item.json
@@ -1,17 +1,14 @@
 {
-  "assetAdministrationShells": [
+  "submodels": [
     {
-      "assetInformation": {
-        "assetKind": "Instance"
-      },
-      "derivedFrom": {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
         "keys": [
           null
         ],
-        "type": "ModelReference"
-      },
-      "id": "something_random_428f0205",
-      "modelType": "AssetAdministrationShell"
+        "type": "GlobalReference"
+      }
     }
   ]
 }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/Reference/keys_value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/Reference/keys_value.json
@@ -1,15 +1,12 @@
 {
-  "assetAdministrationShells": [
+  "submodels": [
     {
-      "assetInformation": {
-        "assetKind": "Instance"
-      },
-      "derivedFrom": {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
         "keys": null,
-        "type": "ModelReference"
-      },
-      "id": "something_random_428f0205",
-      "modelType": "AssetAdministrationShell"
+        "type": "GlobalReference"
+      }
     }
   ]
 }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/Reference/type_value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/NullViolation/Reference/type_value.json
@@ -1,20 +1,17 @@
 {
-  "assetAdministrationShells": [
+  "submodels": [
     {
-      "assetInformation": {
-        "assetKind": "Instance"
-      },
-      "derivedFrom": {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
         "keys": [
           {
-            "type": "AssetAdministrationShell",
-            "value": "44e7dc4a"
+            "type": "GlobalReference",
+            "value": "something_random_920ea681"
           }
         ],
         "type": null
-      },
-      "id": "something_random_428f0205",
-      "modelType": "AssetAdministrationShell"
+      }
     }
   ]
 }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_01.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_02.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_02.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_03.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_03.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_04.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_04.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_05.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_05.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_06.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_07.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_07.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_08.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_08.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_09.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_10.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_10.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/date_time_with_UTC_and_suffix.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/date_time_with_UTC_and_suffix.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/date_time_with_offset.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/date_time_with_offset.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/date_time_without_zone.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/date_time_without_zone.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/empty.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/empty.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_01.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_02.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_02.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_03.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_03.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_04.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_04.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_05.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_05.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_06.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_07.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_07.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_08.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_08.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_09.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_10.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_10.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/only_date.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/only_date.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/only_date_with_time_zone.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/only_date_with_time_zone.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/without_minutes.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/without_minutes.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/without_seconds.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/without_seconds.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/date_time_with_UTC_and_suffix.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/date_time_with_UTC_and_suffix.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/date_time_with_offset.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/date_time_with_offset.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/date_time_without_zone.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/date_time_without_zone.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/empty.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/empty.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_01.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_02.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_02.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_03.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_03.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_04.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_04.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_05.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_05.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_06.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_07.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_07.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_08.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_08.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_09.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_10.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_10.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/only_date.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/only_date.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/only_date_with_time_zone.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/only_date_with_time_zone.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/without_minutes.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/without_minutes.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/without_seconds.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/without_seconds.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/date_time_with_UTC_and_suffix.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/date_time_with_UTC_and_suffix.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/date_time_with_offset.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/date_time_with_offset.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/date_time_without_zone.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/date_time_without_zone.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/empty.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/empty.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_01.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_02.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_02.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_03.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_03.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_04.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_04.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_05.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_05.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_06.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_07.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_07.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_08.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_08.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_09.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_10.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_10.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/only_date.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/only_date.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/only_date_with_time_zone.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/only_date_with_time_zone.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/without_minutes.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/without_minutes.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/without_seconds.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/without_seconds.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/RequiredViolation/BasicEventElement/direction.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/RequiredViolation/BasicEventElement/direction.json
@@ -14,7 +14,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/RequiredViolation/BasicEventElement/state.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/RequiredViolation/BasicEventElement/state.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/RequiredViolation/Reference/keys.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/RequiredViolation/Reference/keys.json
@@ -1,14 +1,11 @@
 {
-  "assetAdministrationShells": [
+  "submodels": [
     {
-      "assetInformation": {
-        "assetKind": "Instance"
-      },
-      "derivedFrom": {
-        "type": "ModelReference"
-      },
-      "id": "something_random_428f0205",
-      "modelType": "AssetAdministrationShell"
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "type": "GlobalReference"
+      }
     }
   ]
 }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/RequiredViolation/Reference/type.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/RequiredViolation/Reference/type.json
@@ -1,19 +1,16 @@
 {
-  "assetAdministrationShells": [
+  "submodels": [
     {
-      "assetInformation": {
-        "assetKind": "Instance"
-      },
-      "derivedFrom": {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
         "keys": [
           {
-            "type": "AssetAdministrationShell",
-            "value": "44e7dc4a"
+            "type": "GlobalReference",
+            "value": "something_random_920ea681"
           }
         ]
-      },
-      "id": "something_random_428f0205",
-      "modelType": "AssetAdministrationShell"
+      }
     }
   ]
 }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/category.json
@@ -60,7 +60,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -76,7 +76,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/checksum.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/checksum.json
@@ -60,7 +60,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -76,7 +76,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/dataSpecifications.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/dataSpecifications.json
@@ -42,7 +42,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -58,7 +58,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/description.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/description.json
@@ -45,7 +45,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -61,7 +61,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/direction.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/direction.json
@@ -52,7 +52,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -68,7 +68,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/displayName.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/displayName.json
@@ -45,7 +45,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -61,7 +61,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/extensions.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/extensions.json
@@ -47,7 +47,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -63,7 +63,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/idShort.json
@@ -60,7 +60,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -76,7 +76,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/kind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/kind.json
@@ -52,7 +52,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -68,7 +68,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/lastUpdate.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/lastUpdate.json
@@ -60,7 +60,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -76,7 +76,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/maxInterval.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/maxInterval.json
@@ -60,7 +60,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -76,7 +76,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json
@@ -56,7 +56,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageTopic.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageTopic.json
@@ -52,7 +52,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -76,7 +76,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/minInterval.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/minInterval.json
@@ -52,7 +52,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -76,7 +76,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json
@@ -52,7 +52,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/qualifiers.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/qualifiers.json
@@ -52,7 +52,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -68,7 +68,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json
@@ -52,7 +52,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -68,7 +68,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/state.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/state.json
@@ -52,7 +52,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -68,7 +68,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/supplementalSemanticIds.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/supplementalSemanticIds.json
@@ -52,7 +52,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -68,7 +68,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/keys.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/keys.json
@@ -1,15 +1,21 @@
 {
-  "assetAdministrationShells": [
+  "submodels": [
     {
-      "assetInformation": {
-        "assetKind": "Instance"
-      },
-      "derivedFrom": {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
         "keys": "Unexpected string value",
-        "type": "ModelReference"
-      },
-      "id": "something_random_428f0205",
-      "modelType": "AssetAdministrationShell"
+        "referredSemanticId": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "something_random_01ef5a5b"
+            }
+          ],
+          "type": "GlobalReference"
+        },
+        "type": "GlobalReference"
+      }
     }
   ]
 }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json
@@ -1,21 +1,18 @@
 {
-  "assetAdministrationShells": [
+  "submodels": [
     {
-      "assetInformation": {
-        "assetKind": "Instance"
-      },
-      "derivedFrom": {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
         "keys": [
           {
-            "type": "AssetAdministrationShell",
-            "value": "44e7dc4a"
+            "type": "GlobalReference",
+            "value": "something_random_920ea681"
           }
         ],
         "referredSemanticId": "Unexpected string value",
-        "type": "ModelReference"
-      },
-      "id": "something_random_428f0205",
-      "modelType": "AssetAdministrationShell"
+        "type": "GlobalReference"
+      }
     }
   ]
 }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/type.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/type.json
@@ -1,20 +1,26 @@
 {
-  "assetAdministrationShells": [
+  "submodels": [
     {
-      "assetInformation": {
-        "assetKind": "Instance"
-      },
-      "derivedFrom": {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
         "keys": [
           {
-            "type": "AssetAdministrationShell",
-            "value": "44e7dc4a"
+            "type": "GlobalReference",
+            "value": "something_random_920ea681"
           }
         ],
+        "referredSemanticId": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "something_random_01ef5a5b"
+            }
+          ],
+          "type": "GlobalReference"
+        },
         "type": "Unexpected string value"
-      },
-      "id": "something_random_428f0205",
-      "modelType": "AssetAdministrationShell"
+      }
     }
   ]
 }

--- a/test_data/Json/SelfContained/Expected/EventPayload/complete.json
+++ b/test_data/Json/SelfContained/Expected/EventPayload/complete.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -29,7 +29,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Expected/EventPayload/minimal.json
+++ b/test_data/Json/SelfContained/Expected/EventPayload/minimal.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/fuzzed_01.json
+++ b/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/fuzzed_01.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/fuzzed_02.json
+++ b/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/fuzzed_02.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/fuzzed_03.json
+++ b/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/fuzzed_03.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/midnight_with_24_hours.json
+++ b/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/midnight_with_24_hours.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/midnight_with_zeros.json
+++ b/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/midnight_with_zeros.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/random_positive.json
+++ b/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/random_positive.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/very_large_year.json
+++ b/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/very_large_year.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/very_long_fractional_second.json
+++ b/test_data/Json/SelfContained/Expected/EventPayload/timeStampOverPatternExamples/very_long_fractional_second.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/DateTimeStampUtcViolationOnFebruary29th/EventPayload/timeStamp.json
+++ b/test_data/Json/SelfContained/Unexpected/DateTimeStampUtcViolationOnFebruary29th/EventPayload/timeStamp.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/MinLengthViolation/EventPayload/payload.json
+++ b/test_data/Json/SelfContained/Unexpected/MinLengthViolation/EventPayload/payload.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -20,7 +20,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/MinLengthViolation/EventPayload/topic.json
+++ b/test_data/Json/SelfContained/Unexpected/MinLengthViolation/EventPayload/topic.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/NullViolation/EventPayload/observableReference_value.json
+++ b/test_data/Json/SelfContained/Unexpected/NullViolation/EventPayload/observableReference_value.json
@@ -7,7 +7,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/NullViolation/EventPayload/source_value.json
+++ b/test_data/Json/SelfContained/Unexpected/NullViolation/EventPayload/source_value.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/NullViolation/EventPayload/timeStamp_value.json
+++ b/test_data/Json/SelfContained/Unexpected/NullViolation/EventPayload/timeStamp_value.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/date_time_with_UTC_and_suffix.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/date_time_with_UTC_and_suffix.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/date_time_with_offset.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/date_time_with_offset.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/date_time_without_zone.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/date_time_without_zone.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/empty.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/empty.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_01.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_01.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_02.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_02.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_03.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_03.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_04.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_04.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_05.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_05.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_06.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_06.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_07.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_07.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_08.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_08.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_09.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_09.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_10.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_10.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/only_date.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/only_date.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/only_date_with_time_zone.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/only_date_with_time_zone.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/without_minutes.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/without_minutes.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/without_seconds.json
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/without_seconds.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/RequiredViolation/EventPayload/observableReference.json
+++ b/test_data/Json/SelfContained/Unexpected/RequiredViolation/EventPayload/observableReference.json
@@ -6,7 +6,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/RequiredViolation/EventPayload/source.json
+++ b/test_data/Json/SelfContained/Unexpected/RequiredViolation/EventPayload/source.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/RequiredViolation/EventPayload/timeStamp.json
+++ b/test_data/Json/SelfContained/Unexpected/RequiredViolation/EventPayload/timeStamp.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -19,7 +19,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json
@@ -17,7 +17,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -21,7 +21,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/payload.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/payload.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -37,7 +37,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -29,7 +29,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -29,7 +29,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/timeStamp.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/timeStamp.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -29,7 +29,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/topic.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/topic.json
@@ -6,7 +6,7 @@
         "value": "something_random_b10c3750"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_65b526ce"
       }
     ],
@@ -29,7 +29,7 @@
         "value": "something_random_3e686d1a"
       },
       {
-        "type": "Referable",
+        "type": "Blob",
         "value": "something_random_95803fdc"
       }
     ],

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/complete.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/complete.xml
@@ -75,7 +75,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -91,7 +91,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_01.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_01.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_02.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_02.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_03.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_03.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_04.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_04.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_05.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_05.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_06.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_06.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_07.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_07.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_08.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_08.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_09.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_09.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_10.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/idShortOverPatternExamples/fuzzed_10.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/fuzzed_01.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/fuzzed_01.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/fuzzed_02.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/fuzzed_02.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/fuzzed_03.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/fuzzed_03.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/midnight_with_24_hours.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/midnight_with_24_hours.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/midnight_with_zeros.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/midnight_with_zeros.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/random_positive.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/random_positive.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/very_large_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/very_large_year.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/very_long_fractional_second.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/lastUpdateOverPatternExamples/very_long_fractional_second.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/fuzzed_01.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/fuzzed_01.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/fuzzed_02.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/fuzzed_02.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/fuzzed_03.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/fuzzed_03.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/midnight_with_24_hours.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/midnight_with_24_hours.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/midnight_with_zeros.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/midnight_with_zeros.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/random_positive.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/random_positive.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/very_large_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/very_large_year.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/very_long_fractional_second.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/maxIntervalOverPatternExamples/very_long_fractional_second.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/fuzzed_01.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/fuzzed_01.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/fuzzed_02.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/fuzzed_02.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/fuzzed_03.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/fuzzed_03.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/midnight_with_24_hours.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/midnight_with_24_hours.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/midnight_with_zeros.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/midnight_with_zeros.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/random_positive.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/random_positive.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/very_large_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/very_large_year.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/very_long_fractional_second.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minIntervalOverPatternExamples/very_long_fractional_second.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minimal.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/basicEventElement/minimal.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Expected/reference/complete.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/reference/complete.xml
@@ -1,19 +1,25 @@
 <environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
-	<assetAdministrationShells>
-		<assetAdministrationShell>
-			<id>something_random_428f0205</id>
-			<derivedFrom>
-				<type>ModelReference</type>
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>GlobalReference</type>
+				<referredSemanticId>
+					<type>GlobalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>something_random_01ef5a5b</value>
+						</key>
+					</keys>
+				</referredSemanticId>
 				<keys>
 					<key>
-						<type>AssetAdministrationShell</type>
-						<value>44e7dc4a</value>
+						<type>GlobalReference</type>
+						<value>something_random_920ea681</value>
 					</key>
 				</keys>
-			</derivedFrom>
-			<assetInformation>
-				<assetKind>Instance</assetKind>
-			</assetInformation>
-		</assetAdministrationShell>
-	</assetAdministrationShells>
+			</semanticId>
+		</submodel>
+	</submodels>
 </environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/reference/for_a_global_reference_first_key_in_generic_globally_identifiables.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/reference/for_a_global_reference_first_key_in_generic_globally_identifiables.xml
@@ -1,0 +1,16 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>GlobalReference</type>
+				<keys>
+					<key>
+						<type>GlobalReference</type>
+						<value>something</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/reference/for_a_global_reference_last_key_in_generic_fragment_keys.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/reference/for_a_global_reference_last_key_in_generic_fragment_keys.xml
@@ -1,0 +1,20 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>GlobalReference</type>
+				<keys>
+					<key>
+						<type>GlobalReference</type>
+						<value>something</value>
+					</key>
+					<key>
+						<type>FragmentReference</type>
+						<value>something_more</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/reference/for_a_global_reference_last_key_in_generic_globally_identifiable.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/reference/for_a_global_reference_last_key_in_generic_globally_identifiable.xml
@@ -1,0 +1,20 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>GlobalReference</type>
+				<keys>
+					<key>
+						<type>GlobalReference</type>
+						<value>something</value>
+					</key>
+					<key>
+						<type>GlobalReference</type>
+						<value>something_more</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/reference/for_a_model_reference_first_key_in_globally_and_aas_identifiables.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/reference/for_a_model_reference_first_key_in_globally_and_aas_identifiables.xml
@@ -1,0 +1,16 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>ModelReference</type>
+				<keys>
+					<key>
+						<type>Submodel</type>
+						<value>something</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/reference/for_a_model_reference_fragment_after_blob.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/reference/for_a_model_reference_fragment_after_blob.xml
@@ -1,0 +1,24 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>ModelReference</type>
+				<keys>
+					<key>
+						<type>Submodel</type>
+						<value>something</value>
+					</key>
+					<key>
+						<type>Blob</type>
+						<value>something_more</value>
+					</key>
+					<key>
+						<type>FragmentReference</type>
+						<value>yet_something_more</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/reference/for_a_model_reference_valid_key_value_after_submodel_element_list.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/reference/for_a_model_reference_valid_key_value_after_submodel_element_list.xml
@@ -1,0 +1,24 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>ModelReference</type>
+				<keys>
+					<key>
+						<type>Submodel</type>
+						<value>something</value>
+					</key>
+					<key>
+						<type>SubmodelElementList</type>
+						<value>something_more</value>
+					</key>
+					<key>
+						<type>Property</type>
+						<value>123</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/reference/minimal.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/reference/minimal.xml
@@ -1,19 +1,16 @@
 <environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
-	<assetAdministrationShells>
-		<assetAdministrationShell>
-			<id>something_random_428f0205</id>
-			<derivedFrom>
-				<type>ModelReference</type>
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>GlobalReference</type>
 				<keys>
 					<key>
-						<type>AssetAdministrationShell</type>
-						<value>44e7dc4a</value>
+						<type>GlobalReference</type>
+						<value>something_random_920ea681</value>
 					</key>
 				</keys>
-			</derivedFrom>
-			<assetInformation>
-				<assetKind>Instance</assetKind>
-			</assetInformation>
-		</assetAdministrationShell>
-	</assetAdministrationShells>
+			</semanticId>
+		</submodel>
+	</submodels>
 </environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/first_key_not_in_globally_identifiables.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/first_key_not_in_globally_identifiables.xml
@@ -1,0 +1,16 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>ModelReference</type>
+				<keys>
+					<key>
+						<type>Blob</type>
+						<value>something</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_global_reference_first_key_not_in_generic_globally_identifiables.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_global_reference_first_key_not_in_generic_globally_identifiables.xml
@@ -1,0 +1,16 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>GlobalReference</type>
+				<keys>
+					<key>
+						<type>Blob</type>
+						<value>something</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_global_reference_invalid_last_key.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_global_reference_invalid_last_key.xml
@@ -1,0 +1,20 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>GlobalReference</type>
+				<keys>
+					<key>
+						<type>GlobalReference</type>
+						<value>something</value>
+					</key>
+					<key>
+						<type>Blob</type>
+						<value>something_more</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_model_reference_first_key_not_in_AAS_identifiables.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_model_reference_first_key_not_in_AAS_identifiables.xml
@@ -1,0 +1,16 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>ModelReference</type>
+				<keys>
+					<key>
+						<type>GlobalReference</type>
+						<value>something</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_model_reference_fragment_reference_in_the_middle.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_model_reference_fragment_reference_in_the_middle.xml
@@ -1,0 +1,24 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>ModelReference</type>
+				<keys>
+					<key>
+						<type>Submodel</type>
+						<value>something</value>
+					</key>
+					<key>
+						<type>FragmentReference</type>
+						<value>something_more</value>
+					</key>
+					<key>
+						<type>Property</type>
+						<value>yet_something_more</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_model_reference_fragment_reference_not_after_file_or_blob.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_model_reference_fragment_reference_not_after_file_or_blob.xml
@@ -1,0 +1,24 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>ModelReference</type>
+				<keys>
+					<key>
+						<type>Submodel</type>
+						<value>something</value>
+					</key>
+					<key>
+						<type>Property</type>
+						<value>something_more</value>
+					</key>
+					<key>
+						<type>FragmentReference</type>
+						<value>yet_something_more</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_model_reference_invalid_key_value_after_submodel_element_list.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_model_reference_invalid_key_value_after_submodel_element_list.xml
@@ -1,0 +1,24 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>ModelReference</type>
+				<keys>
+					<key>
+						<type>Submodel</type>
+						<value>something</value>
+					</key>
+					<key>
+						<type>SubmodelElementList</type>
+						<value>something_more</value>
+					</key>
+					<key>
+						<type>Property</type>
+						<value>-1</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_model_reference_second_key_not_in_fragment_keys.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/ConstraintViolation/reference/for_a_model_reference_second_key_not_in_fragment_keys.xml
@@ -1,0 +1,20 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>ModelReference</type>
+				<keys>
+					<key>
+						<type>Submodel</type>
+						<value>something</value>
+					</key>
+					<key>
+						<type>GlobalReference</type>
+						<value>something_more</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/DateTimeStampUtcViolationOnFebruary29th/basicEventElement/lastUpdate.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/DateTimeStampUtcViolationOnFebruary29th/basicEventElement/lastUpdate.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/DateTimeStampUtcViolationOnFebruary29th/basicEventElement/maxInterval.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/DateTimeStampUtcViolationOnFebruary29th/basicEventElement/maxInterval.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/DateTimeStampUtcViolationOnFebruary29th/basicEventElement/minInterval.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/DateTimeStampUtcViolationOnFebruary29th/basicEventElement/minInterval.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/basicEventElement/direction_as_direction.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/basicEventElement/direction_as_direction.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/basicEventElement/kind_as_modelingKind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/basicEventElement/kind_as_modelingKind.xml
@@ -14,7 +14,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/basicEventElement/state_as_stateOfEvent.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/basicEventElement/state_as_stateOfEvent.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/reference/type_as_referenceTypes.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/reference/type_as_referenceTypes.xml
@@ -1,19 +1,16 @@
 <environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
-	<assetAdministrationShells>
-		<assetAdministrationShell>
-			<id>something_random_428f0205</id>
-			<derivedFrom>
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
 				<type>invalid-literal</type>
 				<keys>
 					<key>
-						<type>AssetAdministrationShell</type>
-						<value>44e7dc4a</value>
+						<type>GlobalReference</type>
+						<value>something_random_920ea681</value>
 					</key>
 				</keys>
-			</derivedFrom>
-			<assetInformation>
-				<assetKind>Instance</assetKind>
-			</assetInformation>
-		</assetAdministrationShell>
-	</assetAdministrationShells>
+			</semanticId>
+		</submodel>
+	</submodels>
 </environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/MaxLengthViolation/basicEventElement/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/MaxLengthViolation/basicEventElement/idShort.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/MinLengthViolation/basicEventElement/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/MinLengthViolation/basicEventElement/category.xml
@@ -14,7 +14,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/MinLengthViolation/basicEventElement/checksum.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/MinLengthViolation/basicEventElement/checksum.xml
@@ -14,7 +14,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/MinLengthViolation/basicEventElement/messageTopic.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/MinLengthViolation/basicEventElement/messageTopic.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/MinLengthViolation/reference/keys.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/MinLengthViolation/reference/keys.xml
@@ -1,14 +1,11 @@
 <environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
-	<assetAdministrationShells>
-		<assetAdministrationShell>
-			<id>something_random_428f0205</id>
-			<derivedFrom>
-				<type>ModelReference</type>
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>GlobalReference</type>
 				<keys/>
-			</derivedFrom>
-			<assetInformation>
-				<assetKind>Instance</assetKind>
-			</assetInformation>
-		</assetAdministrationShell>
-	</assetAdministrationShells>
+			</semanticId>
+		</submodel>
+	</submodels>
 </environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_01.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_01.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_02.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_02.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_03.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_03.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_04.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_04.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_06.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_06.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_08.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_08.xml
@@ -14,7 +14,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_09.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_09.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_10.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_10.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/date_time_with_UTC_and_suffix.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/date_time_with_UTC_and_suffix.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/date_time_with_offset.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/date_time_with_offset.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/date_time_without_zone.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/date_time_without_zone.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/empty.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/empty.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_02.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_02.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_03.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_03.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_04.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_04.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_05.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_05.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_06.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_06.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_08.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_08.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_09.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_09.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_10.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_10.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/only_date.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/only_date.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/only_date_with_time_zone.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/only_date_with_time_zone.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/without_minutes.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/without_minutes.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/without_seconds.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/without_seconds.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/date_time_with_UTC_and_suffix.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/date_time_with_UTC_and_suffix.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/date_time_with_offset.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/date_time_with_offset.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/date_time_without_zone.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/date_time_without_zone.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/empty.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/empty.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_02.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_02.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_03.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_03.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_04.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_04.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_05.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_05.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_06.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_06.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_08.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_08.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_09.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_09.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_10.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_10.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/only_date.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/only_date.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/only_date_with_time_zone.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/only_date_with_time_zone.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/without_minutes.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/without_minutes.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/without_seconds.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/without_seconds.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/date_time_with_UTC_and_suffix.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/date_time_with_UTC_and_suffix.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/date_time_with_offset.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/date_time_with_offset.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/date_time_without_zone.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/date_time_without_zone.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/empty.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/empty.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_02.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_02.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_03.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_03.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_04.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_04.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_05.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_05.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_06.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_06.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_08.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_08.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_09.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_09.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_10.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_10.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/only_date.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/only_date.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/only_date_with_time_zone.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/only_date_with_time_zone.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/without_minutes.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/without_minutes.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/without_seconds.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/without_seconds.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/basicEventElement/direction.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/basicEventElement/direction.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/basicEventElement/state.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/basicEventElement/state.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/reference/keys.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/reference/keys.xml
@@ -1,13 +1,10 @@
 <environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
-	<assetAdministrationShells>
-		<assetAdministrationShell>
-			<id>something_random_428f0205</id>
-			<derivedFrom>
-				<type>ModelReference</type>
-			</derivedFrom>
-			<assetInformation>
-				<assetKind>Instance</assetKind>
-			</assetInformation>
-		</assetAdministrationShell>
-	</assetAdministrationShells>
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>GlobalReference</type>
+			</semanticId>
+		</submodel>
+	</submodels>
 </environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/reference/type.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/RequiredViolation/reference/type.xml
@@ -1,18 +1,15 @@
 <environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
-	<assetAdministrationShells>
-		<assetAdministrationShell>
-			<id>something_random_428f0205</id>
-			<derivedFrom>
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
 				<keys>
 					<key>
-						<type>AssetAdministrationShell</type>
-						<value>44e7dc4a</value>
+						<type>GlobalReference</type>
+						<value>something_random_920ea681</value>
 					</key>
 				</keys>
-			</derivedFrom>
-			<assetInformation>
-				<assetKind>Instance</assetKind>
-			</assetInformation>
-		</assetAdministrationShell>
-	</assetAdministrationShells>
+			</semanticId>
+		</submodel>
+	</submodels>
 </environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/category.xml
@@ -83,7 +83,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -99,7 +99,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/checksum.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/checksum.xml
@@ -83,7 +83,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -99,7 +99,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/dataSpecifications.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/dataSpecifications.xml
@@ -65,7 +65,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -81,7 +81,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/description.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/description.xml
@@ -68,7 +68,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -84,7 +84,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/direction.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/direction.xml
@@ -75,7 +75,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -91,7 +91,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/displayName.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/displayName.xml
@@ -68,7 +68,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -84,7 +84,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/extensions.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/extensions.xml
@@ -70,7 +70,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -86,7 +86,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/idShort.xml
@@ -83,7 +83,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -99,7 +99,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/kind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/kind.xml
@@ -75,7 +75,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -91,7 +91,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/lastUpdate.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/lastUpdate.xml
@@ -75,7 +75,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -91,7 +91,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/maxInterval.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/maxInterval.xml
@@ -75,7 +75,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -91,7 +91,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageBroker.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageBroker.xml
@@ -75,7 +75,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageTopic.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageTopic.xml
@@ -75,7 +75,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -99,7 +99,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/minInterval.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/minInterval.xml
@@ -75,7 +75,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -91,7 +91,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/observed.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/observed.xml
@@ -79,7 +79,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/qualifiers.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/qualifiers.xml
@@ -70,7 +70,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -86,7 +86,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/semanticId.xml
@@ -67,7 +67,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -83,7 +83,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/state.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/state.xml
@@ -75,7 +75,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -91,7 +91,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/supplementalSemanticIds.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/supplementalSemanticIds.xml
@@ -65,7 +65,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -81,7 +81,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/keys.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/keys.xml
@@ -1,14 +1,20 @@
 <environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
-	<assetAdministrationShells>
-		<assetAdministrationShell>
-			<id>something_random_428f0205</id>
-			<derivedFrom>
-				<type>ModelReference</type>
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>GlobalReference</type>
+				<referredSemanticId>
+					<type>GlobalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>something_random_01ef5a5b</value>
+						</key>
+					</keys>
+				</referredSemanticId>
 				<keys>Unexpected string value</keys>
-			</derivedFrom>
-			<assetInformation>
-				<assetKind>Instance</assetKind>
-			</assetInformation>
-		</assetAdministrationShell>
-	</assetAdministrationShells>
+			</semanticId>
+		</submodel>
+	</submodels>
 </environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/referredSemanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/referredSemanticId.xml
@@ -1,20 +1,17 @@
 <environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
-	<assetAdministrationShells>
-		<assetAdministrationShell>
-			<id>something_random_428f0205</id>
-			<derivedFrom>
-				<type>ModelReference</type>
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>GlobalReference</type>
 				<referredSemanticId>Unexpected string value</referredSemanticId>
 				<keys>
 					<key>
-						<type>AssetAdministrationShell</type>
-						<value>44e7dc4a</value>
+						<type>GlobalReference</type>
+						<value>something_random_920ea681</value>
 					</key>
 				</keys>
-			</derivedFrom>
-			<assetInformation>
-				<assetKind>Instance</assetKind>
-			</assetInformation>
-		</assetAdministrationShell>
-	</assetAdministrationShells>
+			</semanticId>
+		</submodel>
+	</submodels>
 </environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/type.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/type.xml
@@ -1,19 +1,25 @@
 <environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
-	<assetAdministrationShells>
-		<assetAdministrationShell>
-			<id>something_random_428f0205</id>
-			<derivedFrom>
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
 				<type>Unexpected string value</type>
+				<referredSemanticId>
+					<type>GlobalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>something_random_01ef5a5b</value>
+						</key>
+					</keys>
+				</referredSemanticId>
 				<keys>
 					<key>
-						<type>AssetAdministrationShell</type>
-						<value>44e7dc4a</value>
+						<type>GlobalReference</type>
+						<value>something_random_920ea681</value>
 					</key>
 				</keys>
-			</derivedFrom>
-			<assetInformation>
-				<assetKind>Instance</assetKind>
-			</assetInformation>
-		</assetAdministrationShell>
-	</assetAdministrationShells>
+			</semanticId>
+		</submodel>
+	</submodels>
 </environment>

--- a/test_data/Xml/SelfContained/Expected/eventPayload/complete.xml
+++ b/test_data/Xml/SelfContained/Expected/eventPayload/complete.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -29,7 +29,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Expected/eventPayload/minimal.xml
+++ b/test_data/Xml/SelfContained/Expected/eventPayload/minimal.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/fuzzed_01.xml
+++ b/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/fuzzed_01.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/fuzzed_02.xml
+++ b/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/fuzzed_02.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/fuzzed_03.xml
+++ b/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/fuzzed_03.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/midnight_with_24_hours.xml
+++ b/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/midnight_with_24_hours.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/midnight_with_zeros.xml
+++ b/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/midnight_with_zeros.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/random_positive.xml
+++ b/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/random_positive.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/very_large_year.xml
+++ b/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/very_large_year.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/very_long_fractional_second.xml
+++ b/test_data/Xml/SelfContained/Expected/eventPayload/timeStampOverPatternExamples/very_long_fractional_second.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/DateTimeStampUtcViolationOnFebruary29th/eventPayload/timeStamp.xml
+++ b/test_data/Xml/SelfContained/Unexpected/DateTimeStampUtcViolationOnFebruary29th/eventPayload/timeStamp.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/MinLengthViolation/eventPayload/payload.xml
+++ b/test_data/Xml/SelfContained/Unexpected/MinLengthViolation/eventPayload/payload.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/MinLengthViolation/eventPayload/topic.xml
+++ b/test_data/Xml/SelfContained/Unexpected/MinLengthViolation/eventPayload/topic.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/date_time_with_UTC_and_suffix.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/date_time_with_UTC_and_suffix.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/date_time_with_offset.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/date_time_with_offset.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/date_time_without_zone.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/date_time_without_zone.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/empty.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/empty.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_02.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_02.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_03.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_03.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_04.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_04.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_05.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_05.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_06.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_06.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_08.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_08.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_09.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_09.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_10.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_10.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/only_date.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/only_date.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/only_date_with_time_zone.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/only_date_with_time_zone.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/without_minutes.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/without_minutes.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/without_seconds.xml
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/without_seconds.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/RequiredViolation/eventPayload/observableReference.xml
+++ b/test_data/Xml/SelfContained/Unexpected/RequiredViolation/eventPayload/observableReference.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/RequiredViolation/eventPayload/source.xml
+++ b/test_data/Xml/SelfContained/Unexpected/RequiredViolation/eventPayload/source.xml
@@ -7,7 +7,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/RequiredViolation/eventPayload/timeStamp.xml
+++ b/test_data/Xml/SelfContained/Unexpected/RequiredViolation/eventPayload/timeStamp.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -20,7 +20,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableReference.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableReference.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableSemanticId.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableSemanticId.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -29,7 +29,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/payload.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/payload.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -29,7 +29,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/source.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/source.xml
@@ -17,7 +17,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/sourceSemanticId.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/sourceSemanticId.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -21,7 +21,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/subjectId.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/subjectId.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -29,7 +29,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/timeStamp.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/timeStamp.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -29,7 +29,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/topic.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/topic.xml
@@ -7,7 +7,7 @@
 				<value>something_random_3e686d1a</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_95803fdc</value>
 			</key>
 		</keys>
@@ -29,7 +29,7 @@
 				<value>something_random_b10c3750</value>
 			</key>
 			<key>
-				<type>Referable</type>
+				<type>Blob</type>
 				<value>something_random_65b526ce</value>
 			</key>
 		</keys>


### PR DESCRIPTION
We write generation for manual test cases of constraints AASd-121 to 128
for the class ``Reference``.

We also had to adapt the other examples of ``Reference`` as the
constraints AASd-121 to 128 are now implemented, and various fallacies
in the test data were eventually revelead.