### PR TITLE
Update to aas-core-meta 1ae5aa0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             "pydocstyle>=2.1.1<3",
             "coverage>=6,<7",
             "twine",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@0d96564#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@1ae5aa0#egg=aas-core-meta",
             "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@dac0ca1#egg=aas-core-codegen",
             "hypothesis==6.46.3",
             "xmlschema==1.10.0",


### PR DESCRIPTION
We simply mark that the update to [aas-core-meta 1ae5aa0] did not cause
any change in the test data.

[aas-core-meta 1ae5aa0]: https://github.com/aas-core-works/aas-core-meta/commit/1ae5aa0