### PR TITLE
Update to latest aas-core-meta and codegen

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(
             "pydocstyle>=2.1.1<3",
             "coverage>=6,<7",
             "twine",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@95e7dbf#egg=aas-core-meta",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@dac0ca1#egg=aas-core-codegen",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@cccea93#egg=aas-core-meta",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@163a890#egg=aas-core-codegen",
             "hypothesis==6.46.3",
             "xmlschema==1.10.0",
         ]

--- a/test_data/schema.xsd
+++ b/test_data/schema.xsd
@@ -3,14 +3,14 @@
   <xs:group name="administrativeInformation">
     <xs:sequence>
       <xs:group ref="hasDataSpecification"/>
-      <xs:element name="version" minOccurs="0">
+      <xs:element name="version" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="revision" minOccurs="0">
+      <xs:element name="revision" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
@@ -22,7 +22,7 @@
   <xs:group name="annotatedRelationshipElement">
     <xs:sequence>
       <xs:group ref="relationshipElement"/>
-      <xs:element name="annotations" minOccurs="0">
+      <xs:element name="annotations" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:group ref="dataElement_choice" minOccurs="1" maxOccurs="unbounded"/>
@@ -35,9 +35,9 @@
     <xs:sequence>
       <xs:group ref="identifiable"/>
       <xs:group ref="hasDataSpecification"/>
-      <xs:element name="derivedFrom" type="reference_t" minOccurs="0"/>
+      <xs:element name="derivedFrom" type="reference_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="assetInformation" type="assetInformation_t"/>
-      <xs:element name="submodels" minOccurs="0">
+      <xs:element name="submodels" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="reference" type="reference_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -49,15 +49,15 @@
   <xs:group name="assetInformation">
     <xs:sequence>
       <xs:element name="assetKind" type="assetKind_t"/>
-      <xs:element name="globalAssetId" type="reference_t" minOccurs="0"/>
-      <xs:element name="specificAssetIds" minOccurs="0">
+      <xs:element name="globalAssetId" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="specificAssetIds" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="specificAssetId" type="specificAssetId_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="defaultThumbnail" type="resource_t" minOccurs="0"/>
+      <xs:element name="defaultThumbnail" type="resource_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="basicEventElement">
@@ -66,29 +66,29 @@
       <xs:element name="observed" type="reference_t"/>
       <xs:element name="direction" type="direction_t"/>
       <xs:element name="state" type="stateOfEvent_t"/>
-      <xs:element name="messageTopic" minOccurs="0">
+      <xs:element name="messageTopic" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="messageBroker" type="reference_t" minOccurs="0"/>
-      <xs:element name="lastUpdate" minOccurs="0">
+      <xs:element name="messageBroker" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lastUpdate" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:pattern value="-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\.[0-9]+)?)|24:00:00(\.0+)?)Z"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="minInterval" minOccurs="0">
+      <xs:element name="minInterval" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:pattern value="-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\.[0-9]+)?)|24:00:00(\.0+)?)Z"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="maxInterval" minOccurs="0">
+      <xs:element name="maxInterval" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:pattern value="-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\.[0-9]+)?)|24:00:00(\.0+)?)Z"/>
@@ -100,7 +100,7 @@
   <xs:group name="blob">
     <xs:sequence>
       <xs:group ref="dataElement"/>
-      <xs:element name="value" type="xs:base64Binary" minOccurs="0"/>
+      <xs:element name="value" type="xs:base64Binary" minOccurs="0" maxOccurs="1"/>
       <xs:element name="contentType">
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -120,7 +120,7 @@
     <xs:sequence>
       <xs:group ref="identifiable"/>
       <xs:group ref="hasDataSpecification"/>
-      <xs:element name="isCaseOf" minOccurs="0">
+      <xs:element name="isCaseOf" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="reference" type="reference_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -163,53 +163,53 @@
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="shortName" minOccurs="0">
+      <xs:element name="shortName" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="langString" type="langString_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="unit" minOccurs="0">
+      <xs:element name="unit" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="unitId" type="reference_t" minOccurs="0"/>
-      <xs:element name="sourceOfDefinition" minOccurs="0">
+      <xs:element name="unitId" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sourceOfDefinition" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="symbol" minOccurs="0">
+      <xs:element name="symbol" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="dataType" type="dataTypeIec61360_t" minOccurs="0"/>
-      <xs:element name="definition" minOccurs="0">
+      <xs:element name="dataType" type="dataTypeIec61360_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="definition" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="langString" type="langString_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="valueFormat" minOccurs="0">
+      <xs:element name="valueFormat" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="valueList" type="valueList_t" minOccurs="0"/>
-      <xs:element name="value" type="xs:string" minOccurs="0"/>
-      <xs:element name="levelType" type="levelType_t" minOccurs="0"/>
+      <xs:element name="valueList" type="valueList_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="levelType" type="levelType_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="dataSpecificationPhysicalUnit">
@@ -236,70 +236,70 @@
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="siNotation" minOccurs="0">
+      <xs:element name="siNotation" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="siName" minOccurs="0">
+      <xs:element name="siName" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="dinNotation" minOccurs="0">
+      <xs:element name="dinNotation" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="eceName" minOccurs="0">
+      <xs:element name="eceName" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="eceCode" minOccurs="0">
+      <xs:element name="eceCode" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="nistName" minOccurs="0">
+      <xs:element name="nistName" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="sourceOfDefinition" minOccurs="0">
+      <xs:element name="sourceOfDefinition" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="conversionFactor" minOccurs="0">
+      <xs:element name="conversionFactor" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="registrationAuthorityId" minOccurs="0">
+      <xs:element name="registrationAuthorityId" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="supplier" minOccurs="0">
+      <xs:element name="supplier" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
@@ -323,7 +323,7 @@
   <xs:group name="entity">
     <xs:sequence>
       <xs:group ref="submodelElement"/>
-      <xs:element name="statements" minOccurs="0">
+      <xs:element name="statements" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:group ref="submodelElement_choice" minOccurs="1" maxOccurs="unbounded"/>
@@ -331,27 +331,27 @@
         </xs:complexType>
       </xs:element>
       <xs:element name="entityType" type="entityType_t"/>
-      <xs:element name="globalAssetId" type="reference_t" minOccurs="0"/>
-      <xs:element name="specificAssetId" type="specificAssetId_t" minOccurs="0"/>
+      <xs:element name="globalAssetId" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="specificAssetId" type="specificAssetId_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="environment">
     <xs:sequence>
-      <xs:element name="assetAdministrationShells" minOccurs="0">
+      <xs:element name="assetAdministrationShells" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="submodels" minOccurs="0">
+      <xs:element name="submodels" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="submodel" type="submodel_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="conceptDescriptions" minOccurs="0">
+      <xs:element name="conceptDescriptions" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="conceptDescription" type="conceptDescription_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -373,17 +373,17 @@
   <xs:group name="eventPayload">
     <xs:sequence>
       <xs:element name="source" type="reference_t"/>
-      <xs:element name="sourceSemanticId" type="reference_t" minOccurs="0"/>
+      <xs:element name="sourceSemanticId" type="reference_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="observableReference" type="reference_t"/>
-      <xs:element name="observableSemanticId" type="reference_t" minOccurs="0"/>
-      <xs:element name="topic" minOccurs="0">
+      <xs:element name="observableSemanticId" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="topic" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="subjectId" type="reference_t" minOccurs="0"/>
+      <xs:element name="subjectId" type="reference_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="timeStamp">
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -391,7 +391,7 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="payload" minOccurs="0">
+      <xs:element name="payload" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
@@ -410,15 +410,15 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="valueType" type="dataTypeDefXsd_t" minOccurs="0"/>
-      <xs:element name="value" type="xs:string" minOccurs="0"/>
-      <xs:element name="refersTo" type="reference_t" minOccurs="0"/>
+      <xs:element name="valueType" type="dataTypeDefXsd_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="refersTo" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="file">
     <xs:sequence>
       <xs:group ref="dataElement"/>
-      <xs:element name="value" minOccurs="0">
+      <xs:element name="value" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:pattern value="file:(//((localhost|(\[((([0-9A-Fa-f]{1,4}:){6}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|::([0-9A-Fa-f]{1,4}:){5}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|([0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){4}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:)?[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){3}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){2}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){2}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){3}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}:([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){4}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){5}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}|(([0-9A-Fa-f]{1,4}:){6}[0-9A-Fa-f]{1,4})?::)|[vV][0-9A-Fa-f]+\.([a-zA-Z0-9\-._~]|[!$&amp;'()*+,;=]|:)+)\]|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])|([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=])*)))?/((([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))*)*)?|/((([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))*)*)?)"/>
@@ -438,7 +438,7 @@
   </xs:group>
   <xs:group name="hasDataSpecification">
     <xs:sequence>
-      <xs:element name="embeddedDataSpecifications" minOccurs="0">
+      <xs:element name="embeddedDataSpecifications" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="embeddedDataSpecification" type="embeddedDataSpecification_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -471,7 +471,7 @@
   </xs:group>
   <xs:group name="hasExtensions">
     <xs:sequence>
-      <xs:element name="extensions" minOccurs="0">
+      <xs:element name="extensions" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="extension" type="extension_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -503,7 +503,7 @@
   </xs:group>
   <xs:group name="hasKind">
     <xs:sequence>
-      <xs:element name="kind" type="modelingKind_t" minOccurs="0"/>
+      <xs:element name="kind" type="modelingKind_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="hasKind_choice">
@@ -527,8 +527,8 @@
   </xs:group>
   <xs:group name="hasSemantics">
     <xs:sequence>
-      <xs:element name="semanticId" type="reference_t" minOccurs="0"/>
-      <xs:element name="supplementalSemanticIds" minOccurs="0">
+      <xs:element name="semanticId" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="supplementalSemanticIds" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="reference" type="reference_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -562,7 +562,7 @@
   <xs:group name="identifiable">
     <xs:sequence>
       <xs:group ref="referable"/>
-      <xs:element name="administration" type="administrativeInformation_t" minOccurs="0"/>
+      <xs:element name="administration" type="administrativeInformation_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="id">
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -606,34 +606,34 @@
   <xs:group name="multiLanguageProperty">
     <xs:sequence>
       <xs:group ref="dataElement"/>
-      <xs:element name="value" minOccurs="0">
+      <xs:element name="value" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="langString" type="langString_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="valueId" type="reference_t" minOccurs="0"/>
+      <xs:element name="valueId" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="operation">
     <xs:sequence>
       <xs:group ref="submodelElement"/>
-      <xs:element name="inputVariables" minOccurs="0">
+      <xs:element name="inputVariables" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="operationVariable" type="operationVariable_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="outputVariables" minOccurs="0">
+      <xs:element name="outputVariables" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="operationVariable" type="operationVariable_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="inoutputVariables" minOccurs="0">
+      <xs:element name="inoutputVariables" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="operationVariable" type="operationVariable_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -657,13 +657,13 @@
     <xs:sequence>
       <xs:group ref="dataElement"/>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" type="xs:string" minOccurs="0"/>
-      <xs:element name="valueId" type="reference_t" minOccurs="0"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="valueId" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="qualifiable">
     <xs:sequence>
-      <xs:element name="qualifiers" minOccurs="0">
+      <xs:element name="qualifiers" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="qualifier" type="qualifier_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -694,7 +694,7 @@
   <xs:group name="qualifier">
     <xs:sequence>
       <xs:group ref="hasSemantics"/>
-      <xs:element name="kind" type="qualifierKind_t" minOccurs="0"/>
+      <xs:element name="kind" type="qualifierKind_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="type">
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -703,29 +703,29 @@
         </xs:simpleType>
       </xs:element>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" type="xs:string" minOccurs="0"/>
-      <xs:element name="valueId" type="reference_t" minOccurs="0"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="valueId" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="range">
     <xs:sequence>
       <xs:group ref="dataElement"/>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="min" type="xs:string" minOccurs="0"/>
-      <xs:element name="max" type="xs:string" minOccurs="0"/>
+      <xs:element name="min" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="max" type="xs:string" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="referable">
     <xs:sequence>
       <xs:group ref="hasExtensions"/>
-      <xs:element name="category" minOccurs="0">
+      <xs:element name="category" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="idShort" minOccurs="0">
+      <xs:element name="idShort" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:pattern value="[a-zA-Z][a-zA-Z0-9_]+"/>
@@ -733,21 +733,21 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="displayName" minOccurs="0">
+      <xs:element name="displayName" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="langString" type="langString_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="description" minOccurs="0">
+      <xs:element name="description" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="langString" type="langString_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="checksum" minOccurs="0">
+      <xs:element name="checksum" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
@@ -780,7 +780,7 @@
   <xs:group name="reference">
     <xs:sequence>
       <xs:element name="type" type="referenceTypes_t"/>
-      <xs:element name="referredSemanticId" type="reference_t" minOccurs="0"/>
+      <xs:element name="referredSemanticId" type="reference_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="keys">
         <xs:complexType>
           <xs:sequence>
@@ -793,7 +793,7 @@
   <xs:group name="referenceElement">
     <xs:sequence>
       <xs:group ref="dataElement"/>
-      <xs:element name="value" type="reference_t" minOccurs="0"/>
+      <xs:element name="value" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="relationshipElement">
@@ -819,7 +819,7 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="contentType" minOccurs="0">
+      <xs:element name="contentType" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:pattern value="([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([\t !#-\[\]-~]|[-ÿ])|\\([\t !-~]|[-ÿ]))*&quot;))*"/>
@@ -856,7 +856,7 @@
       <xs:group ref="hasSemantics"/>
       <xs:group ref="qualifiable"/>
       <xs:group ref="hasDataSpecification"/>
-      <xs:element name="submodelElements" minOccurs="0">
+      <xs:element name="submodelElements" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:group ref="submodelElement_choice" minOccurs="1" maxOccurs="unbounded"/>
@@ -877,7 +877,7 @@
   <xs:group name="submodelElementCollection">
     <xs:sequence>
       <xs:group ref="submodelElement"/>
-      <xs:element name="value" minOccurs="0">
+      <xs:element name="value" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
@@ -889,17 +889,17 @@
   <xs:group name="submodelElementList">
     <xs:sequence>
       <xs:group ref="submodelElement"/>
-      <xs:element name="orderRelevant" type="xs:boolean" minOccurs="0"/>
-      <xs:element name="value" minOccurs="0">
+      <xs:element name="orderRelevant" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="semanticIdListElement" type="reference_t" minOccurs="0"/>
+      <xs:element name="semanticIdListElement" type="reference_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="typeValueListElement" type="aasSubmodelElements_t"/>
-      <xs:element name="valueTypeListElement" type="dataTypeDefXsd_t" minOccurs="0"/>
+      <xs:element name="valueTypeListElement" type="dataTypeDefXsd_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="submodelElement_choice">


### PR DESCRIPTION
We update to:
* [aas-core-meta cccea93] and
* [aas-core-codegen 163a890].

There are no changes in the generated data, but we verify that the
examples comply with the latest XSD.

[aas-core-meta cccea93]: https://github.com/aas-core-works/aas-core-meta/commit/cccea93
[aas-core-codegen 163a890]: https://github.com/aas-core-works/aas-core-codegen/commit/163a890