### PR TITLE
Use meta-model's XML namespace in generation

### DIFF
--- a/aas_core3_0_rc02_testgen/generate_xml.py
+++ b/aas_core3_0_rc02_testgen/generate_xml.py
@@ -164,7 +164,7 @@ class _Serializer:
         impl = minidom.getDOMImplementation()
         assert impl is not None
         doc = impl.createDocument(
-            namespaceURI="http://www.admin-shell.io/aas/3/0/RC02",
+            namespaceURI=self.symbol_table.meta_model.xml_namespace,
             qualifiedName=element_name,
             doctype=None,
         )
@@ -172,7 +172,7 @@ class _Serializer:
         root = doc.documentElement
 
         # noinspection SpellCheckingInspection
-        root.setAttribute("xmlns", "http://www.admin-shell.io/aas/3/0/RC02")
+        root.setAttribute("xmlns", self.symbol_table.meta_model.xml_namespace)
 
         sequence = self._serialize_instance(instance=instance, doc=doc)
         for node in sequence:

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             "pydocstyle>=2.1.1<3",
             "coverage>=6,<7",
             "twine",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@8d909e9#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@1df1729#egg=aas-core-meta",
             "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@163a890#egg=aas-core-codegen",
             "hypothesis==6.46.3",
             "xmlschema==1.10.0",


### PR DESCRIPTION
We use the parsed XML namespace instead of the hard-wired one as the XML
namespace is, somewhat unexpectedly, prone to changes. This change also
makes it easier to copy/paste the scripts for the future versions.