### PR TITLE
Update to meta 3ffe727 and codegen 46ddb38f

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(
             "pydocstyle>=2.1.1<3",
             "coverage>=6,<7",
             "twine",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@e63c0c9#egg=aas-core-meta",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@b33ee59#egg=aas-core-codegen",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@3ffe727#egg=aas-core-meta",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@46ddb38f#egg=aas-core-codegen",
             "hypothesis==6.46.3",
             "xmlschema==1.10.0",
         ]


### PR DESCRIPTION
We update to [aas-core-meta 3ffe727] and [aas-core-codegen 46ddb38f]. This update is necessary as aas-core-meta and codegen need to be updated in sync since we changed the parsing of the references in the meta-model.

[aas-core-codegen 46ddb38f]: https://github.com/aas-core-works/aas-core-codegen/commit/46ddb38f
[aas-core-meta 3ffe727]: https://github.com/aas-core-works/aas-core-meta/commit/3ffe727