### PR TITLE
Add tests for zero and BCE years

### DIFF
--- a/aas_core3_0_rc02_testgen/frozen_examples/xs_value.py
+++ b/aas_core3_0_rc02_testgen/frozen_examples/xs_value.py
@@ -174,6 +174,14 @@ BY_VALUE_TYPE: Mapping[str, Examples] = collections.OrderedDict(
                             "date_with_large_negative_year",
                             "-12345678901234567890123456789012345678901234567890-04-01",
                         ),
+                        (
+                            "year_1_bce_is_a_leap_year",
+                            "-0001-02-29",
+                        ),
+                        (
+                            "year_5_bce_is_a_leap_year",
+                            "-0005-02-29",
+                        ),
                         ("fuzzed_01", "0705-04-1014:00"),
                         ("fuzzed_02", "-0236-12-31Z"),
                         ("fuzzed_03", "9088-11-06"),
@@ -196,6 +204,10 @@ BY_VALUE_TYPE: Mapping[str, Examples] = collections.OrderedDict(
                         ("date_with_invalid_positive_offset", "2022-04-01+15:00"),
                         ("date_with_invalid_negative_offset", "2022-04-01-15:00"),
                         ("date_with_seconds_in_offset", "2022-04-01+02:00:12"),
+                        ("year_zero_doesnt_exist", "0000-01-02"),
+                        # NOTE (mristin, 2022-10-30):
+                        # Year 1 BCE is a leap year.
+                        ("year_4_bce_february_29th", "-0004-02-29"),
                     ]
                 ),
             ),
@@ -224,6 +236,14 @@ BY_VALUE_TYPE: Mapping[str, Examples] = collections.OrderedDict(
                         ),
                         ("midnight_with_zeros", "2022-04-01T00:00:00"),
                         ("midnight_with_24_hours", "2022-04-01T24:00:00"),
+                        (
+                            "year_1_bce_is_a_leap_year",
+                            "-0001-02-29T01:02:03",
+                        ),
+                        (
+                            "year_5_bce_is_a_leap_year",
+                            "-0005-02-29T01:02:03",
+                        ),
                         ("fuzzed_01", "-0811-10-21T24:00:00.000000Z"),
                         ("fuzzed_02", "-0819-11-21T24:00:00.00Z"),
                         ("fuzzed_03", "-665280014-06-30T21:15:16Z"),
@@ -264,6 +284,10 @@ BY_VALUE_TYPE: Mapping[str, Examples] = collections.OrderedDict(
                             "date_time_with_unexpected_prefix",
                             "unexpected-prefix-2022-04-01T01:02:03Z",
                         ),
+                        ("year_zero_doesnt_exist", "0000-01-02T01:02:03"),
+                        # NOTE (mristin, 2022-10-30):
+                        # Year 1 BCE is a leap year.
+                        ("year_4_bce_february_29th", "-0004-02-29T01:02:03"),
                     ]
                 ),
             ),
@@ -300,6 +324,14 @@ BY_VALUE_TYPE: Mapping[str, Examples] = collections.OrderedDict(
                         ),
                         ("midnight_with_zeros", "2022-04-01T00:00:00Z"),
                         ("midnight_with_24_hours", "2022-04-01T24:00:00Z"),
+                        (
+                            "year_1_bce_is_a_leap_year",
+                            "-0001-02-29T01:02:03Z",
+                        ),
+                        (
+                            "year_5_bce_is_a_leap_year",
+                            "-0005-02-29T01:02:03Z",
+                        ),
                         ("fuzzed_01", "0300-04-21T24:00:00.00+11:11"),
                         ("fuzzed_02", "-1000-01-01T00:00:00Z"),
                         ("fuzzed_03", "-60601-02-04T24:00:00.00000000Z"),
@@ -341,6 +373,10 @@ BY_VALUE_TYPE: Mapping[str, Examples] = collections.OrderedDict(
                             "date_time_stamp_with_unexpected_prefix",
                             "unexpected-prefix-2022-04-01T01:02:03Z",
                         ),
+                        ("year_zero_doesnt_exist", "0000-01-02T01:02:03Z"),
+                        # NOTE (mristin, 2022-10-30):
+                        # Year 1 BCE is a leap year.
+                        ("year_4_bce_february_29th", "-0004-02-29T01:02:03Z"),
                     ]
                 ),
             ),

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0001-02-29",
+          "valueType": "xs:date"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0005-02-29",
+          "valueType": "xs:date"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0001-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0005-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0001-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0005-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0001-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0005-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0001-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0005-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0001-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0005-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0001-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0005-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0001-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0005-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0001-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0005-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0001-02-29",
+          "min": "-0001-02-29",
+          "modelType": "Range",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0005-02-29",
+          "min": "-0005-02-29",
+          "modelType": "Range",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0001-02-29T01:02:03",
+          "min": "-0001-02-29T01:02:03",
+          "modelType": "Range",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0005-02-29T01:02:03",
+          "min": "-0005-02-29T01:02:03",
+          "modelType": "Range",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0001-02-29T01:02:03Z",
+          "min": "-0001-02-29T01:02:03Z",
+          "modelType": "Range",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0005-02-29T01:02:03Z",
+          "min": "-0005-02-29T01:02:03Z",
+          "modelType": "Range",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_4_bce_february_29th.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0004-02-29",
+          "min": "-0004-02-29",
+          "modelType": "Range",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_zero_doesnt_exist.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "0000-01-02",
+          "min": "0000-01-02",
+          "modelType": "Range",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_4_bce_february_29th.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0004-02-29T01:02:03",
+          "min": "-0004-02-29T01:02:03",
+          "modelType": "Range",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_zero_doesnt_exist.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "0000-01-02T01:02:03",
+          "min": "0000-01-02T01:02:03",
+          "modelType": "Range",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_4_bce_february_29th.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0004-02-29T01:02:03Z",
+          "min": "-0004-02-29T01:02:03Z",
+          "modelType": "Range",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_zero_doesnt_exist.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "0000-01-02T01:02:03Z",
+          "min": "0000-01-02T01:02:03Z",
+          "modelType": "Range",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_4_bce_february_29th.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0004-02-29",
+          "valueType": "xs:date"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_zero_doesnt_exist.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "0000-01-02",
+          "valueType": "xs:date"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_4_bce_february_29th.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0004-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_zero_doesnt_exist.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "0000-01-02T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_4_bce_february_29th.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0004-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_zero_doesnt_exist.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "0000-01-02T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_4_bce_february_29th.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0004-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_zero_doesnt_exist.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "0000-01-02",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_4_bce_february_29th.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0004-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_zero_doesnt_exist.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "0000-01-02T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_4_bce_february_29th.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0004-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_zero_doesnt_exist.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "0000-01-02T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_4_bce_february_29th.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0004-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_zero_doesnt_exist.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "0000-01-02",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_4_bce_february_29th.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0004-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_zero_doesnt_exist.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "0000-01-02T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_4_bce_february_29th.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0004-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_zero_doesnt_exist.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "0000-01-02T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_428f0205> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_428f0205"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> <https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance> ;
+    ] ;
+    <https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> [
+        rdf:type aas:Extension ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/name> "something_random_8ddedf5d"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/value> "-0001-02-29"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_428f0205> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_428f0205"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> <https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance> ;
+    ] ;
+    <https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> [
+        rdf:type aas:Extension ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/name> "something_random_8ddedf5d"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/value> "-0005-02-29"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_428f0205> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_428f0205"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> <https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance> ;
+    ] ;
+    <https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> [
+        rdf:type aas:Extension ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/name> "something_random_8ddedf5d"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/value> "-0001-02-29T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_428f0205> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_428f0205"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> <https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance> ;
+    ] ;
+    <https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> [
+        rdf:type aas:Extension ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/name> "something_random_8ddedf5d"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/value> "-0005-02-29T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_428f0205> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_428f0205"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> <https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance> ;
+    ] ;
+    <https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> [
+        rdf:type aas:Extension ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/name> "something_random_8ddedf5d"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/value> "-0001-02-29T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_428f0205> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_428f0205"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> <https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance> ;
+    ] ;
+    <https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> [
+        rdf:type aas:Extension ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/name> "something_random_8ddedf5d"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/value> "-0005-02-29T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_1_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_1_bce_is_a_leap_year.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Property ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/value> "-0001-02-29"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_5_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_5_bce_is_a_leap_year.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Property ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/value> "-0005-02-29"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Property ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/value> "-0001-02-29T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Property ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/value> "-0005-02-29T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Property ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/value> "-0001-02-29T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Property ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/value> "-0005-02-29T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> [
+        rdf:type aas:Qualifier ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/type> "something_random_cfd39ba4"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> "-0001-02-29"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> [
+        rdf:type aas:Qualifier ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/type> "something_random_cfd39ba4"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> "-0005-02-29"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> [
+        rdf:type aas:Qualifier ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/type> "something_random_cfd39ba4"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> "-0001-02-29T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> [
+        rdf:type aas:Qualifier ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/type> "something_random_cfd39ba4"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> "-0005-02-29T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> [
+        rdf:type aas:Qualifier ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/type> "something_random_cfd39ba4"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> "-0001-02-29T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> [
+        rdf:type aas:Qualifier ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/type> "something_random_cfd39ba4"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> "-0005-02-29T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.ttl
@@ -1,0 +1,16 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Range ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/min> "-0001-02-29"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/max> "-0001-02-29"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.ttl
@@ -1,0 +1,16 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Range ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/min> "-0005-02-29"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/max> "-0005-02-29"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.ttl
@@ -1,0 +1,16 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Range ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/min> "-0001-02-29T01:02:03"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/max> "-0001-02-29T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.ttl
@@ -1,0 +1,16 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Range ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/min> "-0005-02-29T01:02:03"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/max> "-0005-02-29T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.ttl
@@ -1,0 +1,16 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Range ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/min> "-0001-02-29T01:02:03Z"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/max> "-0001-02-29T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.ttl
@@ -1,0 +1,16 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Range ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/min> "-0005-02-29T01:02:03Z"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/max> "-0005-02-29T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_4_bce_february_29th.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_4_bce_february_29th.ttl
@@ -1,0 +1,16 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Range ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/min> "-0004-02-29"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/max> "-0004-02-29"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_zero_doesnt_exist.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_zero_doesnt_exist.ttl
@@ -1,0 +1,16 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Range ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/min> "0000-01-02"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/max> "0000-01-02"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_4_bce_february_29th.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_4_bce_february_29th.ttl
@@ -1,0 +1,16 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Range ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/min> "-0004-02-29T01:02:03"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/max> "-0004-02-29T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_zero_doesnt_exist.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_zero_doesnt_exist.ttl
@@ -1,0 +1,16 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Range ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/min> "0000-01-02T01:02:03"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/max> "0000-01-02T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_4_bce_february_29th.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_4_bce_february_29th.ttl
@@ -1,0 +1,16 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Range ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/min> "-0004-02-29T01:02:03Z"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/max> "-0004-02-29T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_zero_doesnt_exist.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_zero_doesnt_exist.ttl
@@ -1,0 +1,16 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Range ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/min> "0000-01-02T01:02:03Z"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Range/max> "0000-01-02T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_4_bce_february_29th.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_4_bce_february_29th.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_428f0205> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_428f0205"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> <https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance> ;
+    ] ;
+    <https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> [
+        rdf:type aas:Extension ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/name> "something_random_8ddedf5d"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/value> "-0004-02-29"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_zero_doesnt_exist.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_zero_doesnt_exist.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_428f0205> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_428f0205"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> <https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance> ;
+    ] ;
+    <https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> [
+        rdf:type aas:Extension ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/name> "something_random_8ddedf5d"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/value> "0000-01-02"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_4_bce_february_29th.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_4_bce_february_29th.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_428f0205> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_428f0205"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> <https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance> ;
+    ] ;
+    <https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> [
+        rdf:type aas:Extension ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/name> "something_random_8ddedf5d"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/value> "-0004-02-29T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_zero_doesnt_exist.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_zero_doesnt_exist.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_428f0205> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_428f0205"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> <https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance> ;
+    ] ;
+    <https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> [
+        rdf:type aas:Extension ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/name> "something_random_8ddedf5d"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/value> "0000-01-02T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_4_bce_february_29th.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_4_bce_february_29th.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_428f0205> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_428f0205"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> <https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance> ;
+    ] ;
+    <https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> [
+        rdf:type aas:Extension ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/name> "something_random_8ddedf5d"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/value> "-0004-02-29T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_zero_doesnt_exist.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_zero_doesnt_exist.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_428f0205> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_428f0205"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> <https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance> ;
+    ] ;
+    <https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> [
+        rdf:type aas:Extension ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/name> "something_random_8ddedf5d"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Extension/value> "0000-01-02T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_4_bce_february_29th.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_4_bce_february_29th.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Property ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/value> "-0004-02-29"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_zero_doesnt_exist.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_zero_doesnt_exist.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Property ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/value> "0000-01-02"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_4_bce_february_29th.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_4_bce_february_29th.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Property ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/value> "-0004-02-29T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_zero_doesnt_exist.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_zero_doesnt_exist.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Property ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/value> "0000-01-02T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_4_bce_february_29th.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_4_bce_february_29th.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Property ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/value> "-0004-02-29T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_zero_doesnt_exist.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_zero_doesnt_exist.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> [
+        rdf:type aas:Property ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> "some_id_short_10b21b1b"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Property/value> "0000-01-02T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_4_bce_february_29th.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_4_bce_february_29th.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> [
+        rdf:type aas:Qualifier ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/type> "something_random_cfd39ba4"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> "-0004-02-29"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_zero_doesnt_exist.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_zero_doesnt_exist.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> [
+        rdf:type aas:Qualifier ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/type> "something_random_cfd39ba4"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> "0000-01-02"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_4_bce_february_29th.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_4_bce_february_29th.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> [
+        rdf:type aas:Qualifier ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/type> "something_random_cfd39ba4"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> "-0004-02-29T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_zero_doesnt_exist.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_zero_doesnt_exist.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> [
+        rdf:type aas:Qualifier ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/type> "something_random_cfd39ba4"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> "0000-01-02T01:02:03"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_4_bce_february_29th.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_4_bce_february_29th.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> [
+        rdf:type aas:Qualifier ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/type> "something_random_cfd39ba4"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> "-0004-02-29T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_zero_doesnt_exist.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_zero_doesnt_exist.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_random_b0c234ba> rdf:type aas:Submodel ;
+    <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> "something_random_b0c234ba"^^xs:string ;
+    <https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> [
+        rdf:type aas:Qualifier ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/type> "something_random_cfd39ba4"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> ;
+        <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> "0000-01-02T01:02:03Z"^^xs:string ;
+    ] ;
+.

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:date</valueType>
+					<value>-0001-02-29</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:date</valueType>
+					<value>-0005-02-29</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTime</valueType>
+					<value>-0001-02-29T01:02:03</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTime</valueType>
+					<value>-0005-02-29T01:02:03</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0001-02-29T01:02:03Z</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0005-02-29T01:02:03Z</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<value>-0001-02-29</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<value>-0005-02-29</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<value>-0001-02-29T01:02:03</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<value>-0005-02-29T01:02:03</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0001-02-29T01:02:03Z</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0005-02-29T01:02:03Z</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:date</valueType>
+					<value>-0001-02-29</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:date</valueType>
+					<value>-0005-02-29</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTime</valueType>
+					<value>-0001-02-29T01:02:03</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTime</valueType>
+					<value>-0005-02-29T01:02:03</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0001-02-29T01:02:03Z</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0005-02-29T01:02:03Z</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<min>-0001-02-29</min>
+					<max>-0001-02-29</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<min>-0005-02-29</min>
+					<max>-0005-02-29</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<min>-0001-02-29T01:02:03</min>
+					<max>-0001-02-29T01:02:03</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<min>-0005-02-29T01:02:03</min>
+					<max>-0005-02-29T01:02:03</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<min>-0001-02-29T01:02:03Z</min>
+					<max>-0001-02-29T01:02:03Z</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<min>-0005-02-29T01:02:03Z</min>
+					<max>-0005-02-29T01:02:03Z</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_4_bce_february_29th.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<min>-0004-02-29</min>
+					<max>-0004-02-29</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_zero_doesnt_exist.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<min>0000-01-02</min>
+					<max>0000-01-02</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_4_bce_february_29th.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<min>-0004-02-29T01:02:03</min>
+					<max>-0004-02-29T01:02:03</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_zero_doesnt_exist.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<min>0000-01-02T01:02:03</min>
+					<max>0000-01-02T01:02:03</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_4_bce_february_29th.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<min>-0004-02-29T01:02:03Z</min>
+					<max>-0004-02-29T01:02:03Z</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_zero_doesnt_exist.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<min>0000-01-02T01:02:03Z</min>
+					<max>0000-01-02T01:02:03Z</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_4_bce_february_29th.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:date</valueType>
+					<value>-0004-02-29</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_zero_doesnt_exist.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:date</valueType>
+					<value>0000-01-02</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_4_bce_february_29th.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTime</valueType>
+					<value>-0004-02-29T01:02:03</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_zero_doesnt_exist.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTime</valueType>
+					<value>0000-01-02T01:02:03</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_4_bce_february_29th.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0004-02-29T01:02:03Z</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_zero_doesnt_exist.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>0000-01-02T01:02:03Z</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<value>-0004-02-29</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<value>0000-01-02</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<value>-0004-02-29T01:02:03</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<value>0000-01-02T01:02:03</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0004-02-29T01:02:03Z</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>0000-01-02T01:02:03Z</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:date</valueType>
+					<value>-0004-02-29</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:date</valueType>
+					<value>0000-01-02</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTime</valueType>
+					<value>-0004-02-29T01:02:03</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTime</valueType>
+					<value>0000-01-02T01:02:03</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0004-02-29T01:02:03Z</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>0000-01-02T01:02:03Z</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>


### PR DESCRIPTION
We add tests to check more edge cases when it comes to handling dates. XML dates do not allow for year 0, see [1]. The year "-1" is 1 BCE and it is considered a last leap year BCE, see also [1].

[1]: https://www.w3.org/TR/xmlschema-2/#dateTime